### PR TITLE
fix(register): resolve mobile layout overflow at 380px viewport

### DIFF
--- a/register.html
+++ b/register.html
@@ -48,16 +48,16 @@
 
     <main id="main-content">
       <!-- BENTO REGISTER LAYOUT -->
-      <section class="px-6 py-10 mx-auto max-w-7xl md:px-8 md:py-14">
+      <section class="px-4 py-10 mx-auto max-w-7xl md:px-8 md:py-14">
         <div
-          class="p-6 bg-white md:p-8 lg:p-10"
+          class="p-4 bg-white md:p-8 lg:p-10"
           style="border: 3px solid #1e293b"
         >
           <div class="grid gap-6 lg:grid-cols-[3fr,2fr] lg:gap-8 items-stretch">
             <!-- LEFT: REGISTER TILE -->
             <section
               aria-label="Create Aucto account"
-              class="flex flex-col justify-between p-6 bg-slate-50 md:p-8"
+              class="flex flex-col justify-between p-4 bg-slate-50 md:p-8"
               style="border: 3px solid #1e293b"
             >
               <!-- Label + status -->
@@ -91,7 +91,7 @@
                 </div>
 
                 <h1
-                  class="mb-3 font-serif text-3xl font-bold leading-tight md:text-4xl lg:text-5xl text-slate-900"
+                  class="mb-3 font-serif text-2xl font-bold leading-tight md:text-4xl lg:text-5xl text-slate-900"
                 >
                   Get credits and start listing.
                 </h1>


### PR DESCRIPTION
- Reduce padding on mobile from p-6 to p-4 across all nested containers
- Change heading from text-3xl to text-2xl on mobile for better fit
- Preserve responsive scaling (md:p-8, lg:p-10, md:text-4xl, lg:text-5xl)
- Fix content overflow by reducing total padding from 144px to 96px
- Increases available content width from 236px to 284px on small screens