### PR TITLE
fix: critical bugs, dead code cleanup, and consistent logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+docs/

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -1,14 +1,10 @@
 import type { ApiError } from '../types/api';
-import { clearAuth } from '../utils/storage';
+import { clearAuth, getToken } from '../utils/storage';
 import { showSessionExpiredMessage } from '../utils/authLoader';
 
-// API Configuration
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://v2.api.noroff.dev';
 export const API_KEY = import.meta.env.VITE_API_KEY || '';
 
-/**
- * Custom error class for API errors
- */
 export class ApiErrorClass extends Error {
   statusCode: number;
   errors: Array<{ message: string; code?: string }>;
@@ -21,43 +17,29 @@ export class ApiErrorClass extends Error {
   }
 }
 
-/**
- * Handle 401 Unauthorized responses
- * Clears authentication and redirects to login
- */
 function handleUnauthorized(): void {
-  // Clear stored auth data
   clearAuth();
-
-  // Show session expired notification
   showSessionExpiredMessage();
 
-  // Only redirect if not already on login/register pages
   const currentPath = window.location.pathname;
   if (!currentPath.includes('login') && !currentPath.includes('register')) {
-    // Store the current URL to redirect back after login
     const returnUrl = window.location.pathname + window.location.search;
 
-    // Delay redirect slightly to show the notification
+    // Delay so the toast is visible before navigation
     setTimeout(() => {
       window.location.href = `/login.html?redirect=${encodeURIComponent(returnUrl)}`;
     }, 1000);
   }
 }
 
-/**
- * Base fetch client with authentication and error handling
- */
 export async function apiClient<T>(
   endpoint: string,
   options: RequestInit = {}
 ): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`;
 
-  // Get token from localStorage
-  const token = localStorage.getItem('token');
+  const token = getToken();
 
-  // Set default headers
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
     ...(API_KEY && { 'X-Noroff-API-Key': API_KEY }),
@@ -71,18 +53,17 @@ export async function apiClient<T>(
       headers,
     });
 
-    // Handle empty responses (204 No Content)
+    // 204 No Content
     if (response.status === 204) {
       return {} as T;
     }
 
     const data = await response.json();
 
-    // Check if response is an error
     if (!response.ok) {
       const apiError = new ApiErrorClass(data as ApiError);
 
-      // Handle 401 Unauthorized - token expired or invalid
+      // Token expired or invalid
       if (response.status === 401) {
         handleUnauthorized();
       }
@@ -92,21 +73,16 @@ export async function apiClient<T>(
 
     return data as T;
   } catch (error) {
-    // Re-throw ApiError
     if (error instanceof ApiErrorClass) {
       throw error;
     }
 
-    // Network errors or other issues
     throw new Error(
       error instanceof Error ? error.message : 'Network error occurred'
     );
   }
 }
 
-/**
- * Helper functions for common HTTP methods
- */
 export const api = {
   get: <T>(endpoint: string, options?: RequestInit) =>
     apiClient<T>(endpoint, { ...options, method: 'GET' }),

--- a/src/components/Breadcrumb.ts
+++ b/src/components/Breadcrumb.ts
@@ -1,11 +1,9 @@
-/**
- * Breadcrumb Component
- * Reusable breadcrumb navigation for consistent page navigation
- */
+import { logError } from '../utils/logger';
 
 export interface BreadcrumbItem {
   label: string;
-  href?: string; // If undefined, item is rendered as current page (no link)
+  // Omit href to render as the current page (no link).
+  href?: string;
 }
 
 export interface BreadcrumbConfig {
@@ -14,9 +12,6 @@ export interface BreadcrumbConfig {
   className?: string;
 }
 
-/**
- * Render breadcrumb navigation HTML
- */
 export function renderBreadcrumb(config: BreadcrumbConfig): string {
   const { items, className = '' } = config;
 
@@ -49,29 +44,23 @@ export function renderBreadcrumb(config: BreadcrumbConfig): string {
   `;
 }
 
-/**
- * Render breadcrumb directly into a container element
- */
 export function renderBreadcrumbInContainer(config: BreadcrumbConfig): void {
   const { containerId } = config;
 
   if (!containerId) {
-    console.error('Breadcrumb: containerId is required for renderBreadcrumbInContainer');
+    logError('Breadcrumb: containerId is required for renderBreadcrumbInContainer');
     return;
   }
 
   const container = document.getElementById(containerId);
   if (!container) {
-    console.error(`Breadcrumb: Container with id "${containerId}" not found`);
+    logError(`Breadcrumb: Container with id "${containerId}" not found`);
     return;
   }
 
   container.innerHTML = renderBreadcrumb(config);
 }
 
-/**
- * Update the last breadcrumb item (useful for dynamic titles)
- */
 export function updateLastBreadcrumbItem(containerId: string, newLabel: string): void {
   const container = document.getElementById(containerId);
   if (!container) return;
@@ -82,9 +71,6 @@ export function updateLastBreadcrumbItem(containerId: string, newLabel: string):
   }
 }
 
-/**
- * Common breadcrumb configurations for frequently used pages
- */
 export const BREADCRUMB_PRESETS = {
   home: (): BreadcrumbItem[] => [
     { label: 'Home', href: '/index.html' },

--- a/src/components/CollectionCard.ts
+++ b/src/components/CollectionCard.ts
@@ -1,18 +1,46 @@
 import type { Listing } from '../types/api';
 import { formatTimeRemaining, isAuctionActive } from '../utils/formatDate';
 import { generateResponsiveImageAttrs } from '../utils/imageOptimization';
+import { isWatched, toggleWatched } from '../utils/storage';
+import { logError } from '../utils/logger';
 
-/**
- * Collection Card Component
- * Use for: Catalog pages, collection pages, search results, browse grids
- */
+function renderFavoriteButton(listingId: string, borderStyle: string): string {
+  const watched = isWatched(listingId);
+  const buttonClass = watched
+    ? 'absolute top-3 right-3 bg-red-600 p-2 group/fav transition-all'
+    : 'absolute top-3 right-3 bg-white p-2 hover:bg-slate-900 group/fav transition-all';
+  const svgClass = watched
+    ? 'w-5 h-5 text-white transition-colors'
+    : 'w-5 h-5 text-slate-700 group-hover/fav:text-white transition-colors';
+  const fill = watched ? 'currentColor' : 'none';
 
-/**
- * Create a single Collection Card
- * @param listing - The listing data
- * @param viewMode - 'grid' or 'list' view mode
- * @returns HTML string for the collection card
- */
+  return `
+    <button
+      class="${buttonClass}"
+      style="${borderStyle}"
+      aria-label="${watched ? 'Remove from watchlist' : 'Add to watchlist'}"
+      aria-pressed="${watched}"
+      data-action="toggle-favorite"
+      data-listing-id="${listingId}"
+    >
+      <svg
+        class="${svgClass}"
+        fill="${fill}"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+        />
+      </svg>
+    </button>
+  `;
+}
+
 export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list' = 'grid'): string {
   const isActive = isAuctionActive(listing.endsAt);
   const timeRemaining = formatTimeRemaining(listing.endsAt);
@@ -25,13 +53,10 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
   const imageUrl = listing.media?.[0]?.url || 'https://via.placeholder.com/500x500?text=No+Image';
   const imageAlt = listing.media?.[0]?.alt || listing.title;
 
-  // Generate responsive image attributes
   const imgAttrs = generateResponsiveImageAttrs(imageUrl, imageAlt, 'square');
 
-  // Extract tag for category badge (use first tag or default)
   const tag = listing.tags?.[0] || 'General';
 
-  // Determine status badge based on listing state and urgency
   const getStatusBadge = (): string => {
     if (!isActive) {
       return `
@@ -47,18 +72,16 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
         </div>`;
     }
 
-    // Parse time remaining to determine urgency
     const hoursMatch = timeRemaining.match(/(\d+)h/);
     const hours = hoursMatch ? parseInt(hoursMatch[1]) : 999;
 
+    // Under 6h left = urgency styling (red, pulsing).
     if (hours < 6) {
-      // Less than 6 hours - URGENT (red, pulsing, with fire icon)
       return `
         <div class="absolute top-3 left-3 bg-red-600 px-3 py-2 text-xs font-bold text-white shadow-lg animate-pulse inline-flex items-center gap-1.5" style="border: 2px solid #991b1b">
           <i class="fa-solid fa-fire"></i> ${timeRemaining}
         </div>`;
     } else {
-      // More than 6 hours - normal (green)
       return `
         <div class="absolute top-3 left-3 bg-green-600 px-3 py-1 text-xs font-bold text-white" style="border: 2px solid #15803d">
           ${timeRemaining}
@@ -96,31 +119,11 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
             ${getStatusBadge()}
 
             <!-- Favorite Button -->
-            <button
-              class="absolute top-3 right-3 bg-white p-2 hover:bg-slate-900 group/fav transition-all"
-              style="border: 2px solid #1e293b"
-              title="Add to watchlist"
-              data-action="toggle-favorite"
-              data-listing-id="${listing.id}"
-            >
-              <svg
-                class="w-5 h-5 text-slate-700 group-hover/fav:text-white transition-colors"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-                />
-              </svg>
-            </button>
+            ${renderFavoriteButton(listing.id, 'border: 2px solid #1e293b')}
           </div>
         </div>
 
-        <!-- Content Section (Flex grow to fill space) -->
+        <!-- Content Section -->
         <div class="flex-1 p-6 flex flex-col justify-between">
           <div>
             <!-- Lot Number + Category Badge -->
@@ -138,7 +141,7 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
               </a>
             </h3>
 
-            <!-- Description (truncated for list view) -->
+            <!-- Description -->
             ${listing.description ? `
               <p class="mb-4 text-sm text-slate-600 line-clamp-2">
                 ${listing.description}
@@ -159,7 +162,7 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
             </div>
           </div>
 
-          <!-- Bottom Section: Price + CTA -->
+          <!-- Bottom: Price + CTA -->
           <div class="flex items-center justify-between gap-4 mt-4">
             <!-- Price -->
             <div class="flex items-baseline gap-2">
@@ -192,7 +195,7 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
       data-listing-id="${listing.id}"
     >
       <div class="relative overflow-hidden">
-        <!-- Image with hover effect -->
+        <!-- Image -->
         <div class="aspect-square bg-slate-100 overflow-hidden" style="border-bottom: 3px solid #1e293b">
           <a href="/listing.html?id=${listing.id}" class="block h-full">
             <img
@@ -209,7 +212,7 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
             />
           </a>
 
-          <!-- Overlay on hover -->
+          <!-- Hover overlay -->
           <div class="absolute inset-0 bg-slate-900 bg-opacity-0 group-hover:bg-opacity-40 transition-all duration-300 flex items-center justify-center">
             <button
               class="bg-white px-6 py-3 text-xs font-bold text-slate-900 opacity-0 group-hover:opacity-100 transform translate-y-4 group-hover:translate-y-0 transition-all duration-300"
@@ -226,27 +229,7 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
         ${getStatusBadge()}
 
         <!-- Favorite Button -->
-        <button
-          class="absolute top-3 right-3 bg-white p-2 hover:bg-slate-900 group/fav transition-all"
-          style="border: 3px solid #1e293b"
-          title="Add to watchlist"
-          data-action="toggle-favorite"
-          data-listing-id="${listing.id}"
-        >
-          <svg
-            class="w-5 h-5 text-slate-700 group-hover/fav:text-white transition-colors"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
-            />
-          </svg>
-        </button>
+        ${renderFavoriteButton(listing.id, 'border: 3px solid #1e293b')}
       </div>
 
       <!-- Content -->
@@ -301,12 +284,6 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
   `;
 }
 
-/**
- * Render Collection Cards in a grid container
- * @param listings - Array of listing data
- * @param containerId - ID of the container element
- * @param viewMode - 'grid' or 'list' view mode
- */
 export function renderCollectionCards(
   listings: Listing[],
   containerId: string = 'collection-cards-grid',
@@ -314,7 +291,7 @@ export function renderCollectionCards(
 ): void {
   const container = document.getElementById(containerId);
   if (!container) {
-    console.error(`Container with id "${containerId}" not found`);
+    logError(`Container with id "${containerId}" not found`);
     return;
   }
 
@@ -335,22 +312,16 @@ export function renderCollectionCards(
     return;
   }
 
-  // Render all cards
   container.innerHTML = listings.map(listing => createCollectionCard(listing, viewMode)).join('');
 
-  // Attach event listeners for interactive elements
   attachCollectionCardEvents(containerId);
 }
 
-/**
- * Attach event listeners to Collection Card interactive elements
- * @param containerId - ID of the container element
- */
 export function attachCollectionCardEvents(containerId: string = 'collection-cards-grid'): void {
   const container = document.getElementById(containerId);
   if (!container) return;
 
-  // Handle "View & Bid" button clicks
+  // View & Bid buttons
   const viewBidButtons = container.querySelectorAll<HTMLButtonElement>('[data-action="view-bid"]');
   viewBidButtons.forEach(button => {
     button.addEventListener('click', (event) => {
@@ -358,16 +329,15 @@ export function attachCollectionCardEvents(containerId: string = 'collection-car
       const listingId = button.getAttribute('data-listing-id');
 
       if (!listingId) {
-        console.error('No listing ID found on button');
+        logError('View & Bid button missing data-listing-id');
         return;
       }
 
-      // Redirect to listing detail page (it will handle authentication if needed)
       window.location.href = `/listing.html?id=${listingId}`;
     });
   });
 
-  // Handle "Quick View" button clicks
+  // Quick View buttons
   const quickViewButtons = container.querySelectorAll<HTMLButtonElement>('[data-action="quick-view"]');
   quickViewButtons.forEach(button => {
     button.addEventListener('click', (event) => {
@@ -376,50 +346,57 @@ export function attachCollectionCardEvents(containerId: string = 'collection-car
       const listingId = button.getAttribute('data-listing-id');
 
       if (!listingId) {
-        console.error('No listing ID found on button');
+        logError('Quick view button missing data-listing-id');
         return;
       }
 
-      // Redirect to listing detail page
       window.location.href = `/listing.html?id=${listingId}`;
     });
   });
 
-  // Handle "Favorite" button clicks
+  // Favorite buttons (persist to watchlist in localStorage)
   const favoriteButtons = container.querySelectorAll<HTMLButtonElement>('[data-action="toggle-favorite"]');
   favoriteButtons.forEach(button => {
     button.addEventListener('click', (event) => {
       event.preventDefault();
       event.stopPropagation();
 
-      // Toggle favorite state (visual only for now)
-      const svg = button.querySelector('svg');
-      if (svg) {
-        const currentFill = svg.getAttribute('fill');
-        if (currentFill === 'none') {
-          // Add to favorites
-          svg.setAttribute('fill', 'currentColor');
-          button.classList.add('bg-red-600');
-          button.querySelector('svg')?.classList.remove('text-slate-700');
-          button.querySelector('svg')?.classList.add('text-white');
-        } else {
-          // Remove from favorites
-          svg.setAttribute('fill', 'none');
-          button.classList.remove('bg-red-600');
-          button.querySelector('svg')?.classList.remove('text-white');
-          button.querySelector('svg')?.classList.add('text-slate-700');
-        }
+      const listingId = button.getAttribute('data-listing-id');
+      if (!listingId) {
+        logError('Favorite button missing data-listing-id');
+        return;
       }
 
-      // In the future, save favorite state to API
-      // const listingId = button.getAttribute('data-listing-id');
+      const nowWatched = toggleWatched(listingId);
+      const svg = button.querySelector('svg');
+
+      button.setAttribute('aria-pressed', String(nowWatched));
+      button.setAttribute(
+        'aria-label',
+        nowWatched ? 'Remove from watchlist' : 'Add to watchlist'
+      );
+
+      if (nowWatched) {
+        button.classList.remove('bg-white', 'hover:bg-slate-900');
+        button.classList.add('bg-red-600');
+        if (svg) {
+          svg.setAttribute('fill', 'currentColor');
+          svg.classList.remove('text-slate-700', 'group-hover/fav:text-white');
+          svg.classList.add('text-white');
+        }
+      } else {
+        button.classList.remove('bg-red-600');
+        button.classList.add('bg-white', 'hover:bg-slate-900');
+        if (svg) {
+          svg.setAttribute('fill', 'none');
+          svg.classList.remove('text-white');
+          svg.classList.add('text-slate-700', 'group-hover/fav:text-white');
+        }
+      }
     });
   });
 }
 
-/**
- * Create loading skeleton for Collection Card
- */
 export function createCollectionCardSkeleton(): string {
   return `
     <div class="bg-white animate-pulse" style="border: 2px solid #1e293b">
@@ -438,18 +415,13 @@ export function createCollectionCardSkeleton(): string {
   `;
 }
 
-/**
- * Show loading skeletons in the container
- * @param count - Number of skeletons to show
- * @param containerId - ID of the container element
- */
 export function showCollectionCardSkeletons(
   count: number = 8,
   containerId: string = 'collection-cards-grid'
 ): void {
   const container = document.getElementById(containerId);
   if (!container) {
-    console.error(`Container with id "${containerId}" not found`);
+    logError(`Container with id "${containerId}" not found`);
     return;
   }
 

--- a/src/components/FeaturedWin.ts
+++ b/src/components/FeaturedWin.ts
@@ -1,11 +1,7 @@
-/**
- * Featured Win component for logged-in users
- * Displays a recent winning auction in the footer
- */
-
 import { getCurrentUser } from '../utils/auth';
 import { getProfileWins } from '../api/profile';
 import { getListings } from '../api/listings';
+import { logError } from '../utils/logger';
 import type { Listing } from '../types/api';
 
 export interface FeaturedWinData {
@@ -23,17 +19,11 @@ export interface FeaturedWinData {
   isEnded: boolean; 
 }
 
-/**
- * Get the highest bid amount from a listing
- */
 function getHighestBid(listing: Listing): number {
   if (!listing.bids || listing.bids.length === 0) return 0;
   return Math.max(...listing.bids.map(bid => bid.amount));
 }
 
-/**
- * Get winning bidder information
- */
 function getWinner(listing: Listing) {
   if (!listing.bids || listing.bids.length === 0) return null;
 
@@ -43,21 +33,12 @@ function getWinner(listing: Listing) {
   return winningBid.bidder;
 }
 
-/**
- * Generate a lot number from listing ID
- */
 function getLotNumber(listingId: string): string {
-  // Use last 3 characters of ID as lot number
   return listingId.slice(-3).toUpperCase();
 }
 
-/**
- * Render the featured win component
- * @param data - Featured win data to display
- * @returns HTML string for the featured win section
- */
 export function renderFeaturedWin(data: FeaturedWinData): string {
-  // Determine label and status based on auction state
+  // Label and status based on auction state
   let labelText: string;
   let statusText: string;
   let statusColor: string;
@@ -139,9 +120,6 @@ export function renderFeaturedWin(data: FeaturedWinData): string {
   `;
 }
 
-/**
- * Convert listing to FeaturedWinData
- */
 function convertListingToFeaturedWin(listing: Listing, currentUserName?: string): FeaturedWinData | null {
   const winner = getWinner(listing);
   if (!winner) return null;
@@ -166,11 +144,7 @@ function convertListingToFeaturedWin(listing: Listing, currentUserName?: string)
   };
 }
 
-/**
- * Fetch featured win data from API
- * Priority: User's most recent win > Recently ended auction with bids
- * @returns Promise with featured win data or null if none found
- */
+// Priority: user's most recent win > recently ended auction with bids > active auction with most bids.
 export async function fetchFeaturedWin(): Promise<FeaturedWinData | null> {
   try {
     const user = getCurrentUser();
@@ -234,29 +208,25 @@ export async function fetchFeaturedWin(): Promise<FeaturedWinData | null> {
     return convertListingToFeaturedWin(featuredListing, user.name);
 
   } catch (error) {
-    console.error('Error fetching featured win:', error);
+    logError('Failed to fetch featured win', error);
     return null;
   }
 }
 
-/**
- * Initialize featured win component with dynamic data
- * Fetches data from API and renders the component
- */
 export async function initFeaturedWin(): Promise<void> {
   const container = document.getElementById('featured-win-container');
   if (!container) {
     return;
   }
 
-  // Check if user is logged in
+  // Hide for guests
   const user = getCurrentUser();
   if (!user) {
-    container.innerHTML = ''; // Don't show for guests
+    container.innerHTML = '';
     return;
   }
 
-  // Show loading state
+  // Loading state
   container.innerHTML = `
     <div class="mb-20 bg-slate-800 p-10 lg:p-12 flex items-center justify-center" style="border: 3px solid #334155">
       <div class="text-slate-400">
@@ -265,14 +235,12 @@ export async function initFeaturedWin(): Promise<void> {
     </div>
   `;
 
-  // Fetch data
   const data = await fetchFeaturedWin();
 
   if (!data) {
-    container.innerHTML = ''; // Hide if no data
+    container.innerHTML = '';
     return;
   }
 
-  // Render component
   container.innerHTML = renderFeaturedWin(data);
 }

--- a/src/components/Navbar.ts
+++ b/src/components/Navbar.ts
@@ -11,17 +11,13 @@ import {
   initActiveOnlyCheckbox,
   initSortDropdown,
 } from './filters';
+import { logError } from '../utils/logger';
 import type { User } from '../types/api';
 
-// Cache for user profile data with 30-second TTL
+// 30-second profile cache so credits stay fresh without refetching every page render
 let profileCache: { data: User; timestamp: number } | null = null;
-const CACHE_TTL = 30000; // 30 seconds
+const CACHE_TTL = 30000;
 
-/**
- * Render the header/navigation component
- * Fetches fresh user data to ensure credits are up to date (with 30s cache)
- * Renders different navbar variants based on data-page-type attribute
- */
 export async function renderHeader(): Promise<void> {
   const header = document.getElementById('header');
   if (!header) return;
@@ -63,7 +59,7 @@ export async function renderHeader(): Promise<void> {
         }
       } catch (error) {
         // If fetch fails, continue with cached user data
-        console.error('Failed to fetch fresh user data:', error);
+        logError('Failed to fetch fresh user data', error);
       }
     }
   }
@@ -89,9 +85,7 @@ export async function renderHeader(): Promise<void> {
   initHeaderEvents(pageType);
 }
 
-/**
- * Render minimal navbar for auth pages (login, register)
- */
+// Minimal navbar for auth pages (login, register)
 function renderMinimalNavbar(): string {
   return `
     <nav aria-label="Main navigation" style="background-color: #f7f7f5">
@@ -118,9 +112,7 @@ function renderMinimalNavbar(): string {
   `;
 }
 
-/**
- * Render simple navbar for user content pages (profile, create/edit listing)
- */
+// Simple navbar for user content pages (profile, create/edit listing)
 function renderSimpleNavbar(isUserLoggedIn: boolean, user: User | null): string {
   return `
     <nav aria-label="Main navigation" style="background-color: #f7f7f5">
@@ -176,9 +168,7 @@ function renderSimpleNavbar(isUserLoggedIn: boolean, user: User | null): string 
   `;
 }
 
-/**
- * Render full navbar for browse pages (index, collection, listing details)
- */
+// Full navbar for browse pages (index, collection, listing details)
 function renderFullNavbar(isUserLoggedIn: boolean, user: User | null): string {
   return `
     <nav aria-label="Main navigation" style="background-color: #f7f7f5">
@@ -337,9 +327,7 @@ function renderFullNavbar(isUserLoggedIn: boolean, user: User | null): string {
   `;
 }
 
-/**
- * Render user section (credits + profile dropdown OR auth buttons)
- */
+// User section: credits + profile dropdown for logged-in users, auth buttons for guests
 function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
   return `
     <div class="flex items-center gap-3">
@@ -466,9 +454,6 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
   `;
 }
 
-/**
- * Render mobile menu drawer
- */
 function renderMobileMenu(isUserLoggedIn: boolean, user: User | null): string {
   return `
     <!-- MOBILE MENU DRAWER -->
@@ -600,9 +585,6 @@ function renderMobileMenu(isUserLoggedIn: boolean, user: User | null): string {
   `;
 }
 
-/**
- * Initialize header event listeners based on page type
- */
 function initHeaderEvents(pageType: string): void {
   // Mobile menu drawer
   const mobileMenuBtn = document.getElementById('mobile-menu-btn');
@@ -698,9 +680,7 @@ function initHeaderEvents(pageType: string): void {
   }
 }
 
-/**
- * Initialize events specific to browse pages (search, filters)
- */
+// Search + filter events, only used on browse pages
 function initBrowsePageEvents(): void {
   // Get filter elements
   const filtersBar = document.getElementById('advanced-filters-bar');

--- a/src/components/Newsletter.ts
+++ b/src/components/Newsletter.ts
@@ -1,12 +1,5 @@
-/**
- * Newsletter subscription component for guest users
- * Displays a newsletter signup form in the footer
- */
+import { isValidEmail } from '../utils/validation';
 
-/**
- * Render the newsletter component
- * @returns HTML string for the newsletter section
- */
 export function renderNewsletter(): string {
   return `
     <div class="mb-20 bg-slate-800 p-10 lg:p-12" style="border: 3px solid #334155">
@@ -53,10 +46,6 @@ export function renderNewsletter(): string {
   `;
 }
 
-/**
- * Initialize newsletter form functionality
- * Handles form submission and validation
- */
 export function initNewsletter(): void {
   const form = document.getElementById('newsletter-form') as HTMLFormElement;
   const emailInput = document.getElementById('newsletter-email') as HTMLInputElement;
@@ -95,8 +84,7 @@ export function initNewsletter(): void {
     `;
 
     try {
-      // In a real application, would send this to  API
-      // For now, just simulate a successful subscription
+      // Simulated subscription — no backend wired up yet
       await new Promise(resolve => setTimeout(resolve, 1000));
 
       // Success state
@@ -120,7 +108,7 @@ export function initNewsletter(): void {
         submitBtn.classList.add('bg-slate-900', 'hover:bg-slate-800');
       }, 3000);
 
-    } catch (error) {
+    } catch {
       // Error state
       submitBtn.disabled = false;
       submitBtn.innerHTML = originalBtnContent;
@@ -128,9 +116,6 @@ export function initNewsletter(): void {
     }
   });
 
-  /**
-   * Display error message
-   */
   function showError(message: string): void {
     if (!errorDiv || !emailInput) return;
     errorDiv.textContent = message;
@@ -139,9 +124,6 @@ export function initNewsletter(): void {
     emailInput.focus();
   }
 
-  /**
-   * Display success message
-   */
   function showSuccess(message: string): void {
     if (!errorDiv) return;
     errorDiv.textContent = message;
@@ -153,13 +135,5 @@ export function initNewsletter(): void {
       errorDiv.classList.remove('text-green-400');
       errorDiv.classList.add('text-red-400');
     }, 5000);
-  }
-
-  /**
-   * Validate email format
-   */
-  function isValidEmail(email: string): boolean {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
   }
 }

--- a/src/components/ProductCard.ts
+++ b/src/components/ProductCard.ts
@@ -4,17 +4,9 @@ import { formatCurrency } from '../utils/formatCurrency';
 import { isLoggedIn } from '../utils/auth';
 import { toast } from './Toast';
 import { generateResponsiveImageAttrs } from '../utils/imageOptimization';
+import { logError } from '../utils/logger';
 
-/**
- * Product Card Component
- * Use for: Featured sections, trending auctions, highlighted items
- */
-
-/**
- * Create a single Product Card
- * @param listing - The listing data
- * @returns HTML string for the product card
- */
+// Product Card — use for featured sections, trending auctions, highlighted items.
 export function createProductCard(listing: Listing): string {
   const isActive = isAuctionActive(listing.endsAt);
   const timeRemaining = formatTimeRemaining(listing.endsAt);
@@ -153,18 +145,13 @@ export function createProductCard(listing: Listing): string {
   `;
 }
 
-/**
- * Render Product Cards in a grid container
- * @param listings - Array of listing data
- * @param containerId - ID of the container element
- */
 export function renderProductCards(
   listings: Listing[],
   containerId: string = 'product-cards-grid'
 ): void {
   const container = document.getElementById(containerId);
   if (!container) {
-    console.error(`Container with id "${containerId}" not found`);
+    logError(`Container with id "${containerId}" not found`);
     return;
   }
 
@@ -186,15 +173,11 @@ export function renderProductCards(
   attachProductCardEvents(containerId);
 }
 
-/**
- * Attach event listeners to Product Card buttons
- * @param containerId - ID of the container element
- */
 export function attachProductCardEvents(containerId: string = 'product-cards-grid'): void {
   const container = document.getElementById(containerId);
   if (!container) return;
 
-  // Handle "Place Bid" button clicks
+  // Place Bid buttons
   const bidButtons = container.querySelectorAll<HTMLButtonElement>('[data-action="place-bid"]');
 
   bidButtons.forEach(button => {
@@ -203,11 +186,10 @@ export function attachProductCardEvents(containerId: string = 'product-cards-gri
       const listingId = button.getAttribute('data-listing-id');
 
       if (!listingId) {
-        console.error('No listing ID found on button');
+        logError('Product card button missing data-listing-id');
         return;
       }
 
-      // Check if user is logged in
       if (!isLoggedIn()) {
         toast.error('Please log in to place a bid');
         setTimeout(() => {
@@ -216,15 +198,11 @@ export function attachProductCardEvents(containerId: string = 'product-cards-gri
         return;
       }
 
-      // Redirect to listing detail page where user can place bid
       window.location.href = `/listing.html?id=${listingId}`;
     });
   });
 }
 
-/**
- * Create loading skeleton for Product Card
- */
 export function createProductCardSkeleton(): string {
   return `
     <div class="bg-white animate-pulse" style="border: 3px solid #1e293b">
@@ -252,18 +230,13 @@ export function createProductCardSkeleton(): string {
   `;
 }
 
-/**
- * Show loading skeletons in the container
- * @param count - Number of skeletons to show
- * @param containerId - ID of the container element
- */
 export function showProductCardSkeletons(
   count: number = 3,
   containerId: string = 'product-cards-grid'
 ): void {
   const container = document.getElementById(containerId);
   if (!container) {
-    console.error(`Container with id "${containerId}" not found`);
+    logError(`Container with id "${containerId}" not found`);
     return;
   }
 

--- a/src/components/QuickCard.ts
+++ b/src/components/QuickCard.ts
@@ -4,17 +4,9 @@ import { formatCurrency } from '../utils/formatCurrency';
 import { isLoggedIn } from '../utils/auth';
 import { toast } from './Toast';
 import { generateResponsiveImageAttrs } from '../utils/imageOptimization';
+import { logError } from '../utils/logger';
 
-/**
- * Quick Card Component
- * Use for: Ending soon sections, urgent listings, compact displays
- */
-
-/**
- * Create a single Quick Card
- * @param listing - The listing data
- * @returns HTML string for the quick card
- */
+// Quick Card — use for ending-soon sections, urgent listings, compact displays.
 export function createQuickCard(listing: Listing): string {
   const isActive = isAuctionActive(listing.endsAt);
   const timeRemaining = formatTimeRemaining(listing.endsAt);
@@ -106,18 +98,13 @@ export function createQuickCard(listing: Listing): string {
   `;
 }
 
-/**
- * Render Quick Cards in a grid container
- * @param listings - Array of listing data
- * @param containerId - ID of the container element
- */
 export function renderQuickCards(
   listings: Listing[],
   containerId: string = 'quick-cards-grid'
 ): void {
   const container = document.getElementById(containerId);
   if (!container) {
-    console.error(`Container with id "${containerId}" not found`);
+    logError(`Container with id "${containerId}" not found`);
     return;
   }
 
@@ -139,15 +126,11 @@ export function renderQuickCards(
   attachQuickCardEvents(containerId);
 }
 
-/**
- * Attach event listeners to Quick Card buttons
- * @param containerId - ID of the container element
- */
 export function attachQuickCardEvents(containerId: string = 'quick-cards-grid'): void {
   const container = document.getElementById(containerId);
   if (!container) return;
 
-  // Handle "Place Bid" button clicks
+  // Place Bid buttons
   const bidButtons = container.querySelectorAll<HTMLButtonElement>('[data-action="place-bid"]');
 
   bidButtons.forEach(button => {
@@ -156,11 +139,10 @@ export function attachQuickCardEvents(containerId: string = 'quick-cards-grid'):
       const listingId = button.getAttribute('data-listing-id');
 
       if (!listingId) {
-        console.error('No listing ID found on button');
+        logError('Quick card button missing data-listing-id');
         return;
       }
 
-      // Check if user is logged in
       if (!isLoggedIn()) {
         toast.error('Please log in to place a bid');
         setTimeout(() => {
@@ -169,15 +151,11 @@ export function attachQuickCardEvents(containerId: string = 'quick-cards-grid'):
         return;
       }
 
-      // Redirect to listing detail page where user can place bid
       window.location.href = `/listing.html?id=${listingId}`;
     });
   });
 }
 
-/**
- * Create loading skeleton for Quick Card
- */
 export function createQuickCardSkeleton(): string {
   return `
     <div class="bg-white animate-pulse" style="border: 3px solid #1e293b">
@@ -196,18 +174,13 @@ export function createQuickCardSkeleton(): string {
   `;
 }
 
-/**
- * Show loading skeletons in the container
- * @param count - Number of skeletons to show
- * @param containerId - ID of the container element
- */
 export function showQuickCardSkeletons(
   count: number = 4,
   containerId: string = 'quick-cards-grid'
 ): void {
   const container = document.getElementById(containerId);
   if (!container) {
-    console.error(`Container with id "${containerId}" not found`);
+    logError(`Container with id "${containerId}" not found`);
     return;
   }
 

--- a/src/components/StatsBar.ts
+++ b/src/components/StatsBar.ts
@@ -1,36 +1,16 @@
-/**
- * Stats Bar component for logged-in users
- * Displays user-specific and platform statistics in the footer
- */
-
 import { getCurrentUser } from '../utils/auth';
 import { getProfileListings, getProfileBids, getProfileWins } from '../api/profile';
+import { formatCurrency } from '../utils/formatCurrency';
+import { logError } from '../utils/logger';
 import type { Bid } from '../types/api';
 
 export interface StatsData {
   myListings: number;
   myBids: number;
-  winRate: number; 
+  winRate: number;
   activeBidsValue: number;
 }
 
-/**
- * Format currency for display
- */
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(amount);
-}
-
-/**
- * Render the stats bar component
- * @param data - Stats data to display
- * @returns HTML string for the stats bar section
- */
 export function renderStatsBar(data: StatsData): string {
   return `
     <div class="mb-20 grid grid-cols-2 gap-6 md:grid-cols-4">
@@ -63,7 +43,7 @@ export function renderStatsBar(data: StatsData): string {
 
       <div class="bg-slate-800 p-6 text-center" style="border: 3px solid #334155">
         <div class="mb-2 text-4xl font-bold text-white" data-stat="activeBidsValue">
-          ${formatCurrency(data.activeBidsValue)}
+          ${formatCurrency(data.activeBidsValue, true)}
         </div>
         <div class="text-xs font-bold tracking-widest text-slate-400 uppercase">
           Active Bids
@@ -73,22 +53,22 @@ export function renderStatsBar(data: StatsData): string {
   `;
 }
 
-/**
- * Calculate win rate percentage
- * @param totalBids - Total number of bids placed
- * @param totalWins - Total number of auctions won
- * @returns Win rate as a percentage (0-100)
- */
-function calculateWinRate(totalBids: number, totalWins: number): number {
-  if (totalBids === 0) return 0;
-  return (totalWins / totalBids) * 100;
+// Win rate = wins / unique auctions bid on. Multiple bids on the same listing count as one attempt.
+function calculateWinRate(attemptedAuctions: number, totalWins: number): number {
+  if (attemptedAuctions === 0) return 0;
+  const rate = (totalWins / attemptedAuctions) * 100;
+  return Math.min(rate, 100);
 }
 
-/**
- * Calculate total value of active bids
- * @param bids - Array of user's bids with listing details
- * @returns Total value of bids on auctions that haven't ended yet
- */
+function countAuctionsBidOn(bids: Bid[]): number {
+  const ids = new Set<string>();
+  for (const bid of bids) {
+    if (bid.listing?.id) ids.add(bid.listing.id);
+  }
+  return ids.size;
+}
+
+// Sum of bids on auctions that haven't ended yet
 function calculateActiveBidsValue(bids: Bid[]): number {
   const now = new Date();
   return bids
@@ -96,10 +76,6 @@ function calculateActiveBidsValue(bids: Bid[]): number {
     .reduce((total, bid) => total + bid.amount, 0);
 }
 
-/**
- * Fetch real stats data from API for logged-in user
- * @returns Promise with stats data or null if error
- */
 export async function fetchStats(): Promise<StatsData | null> {
   try {
     const user = getCurrentUser();
@@ -107,40 +83,33 @@ export async function fetchStats(): Promise<StatsData | null> {
       return null;
     }
 
-    // Fetch data in parallel for better performance
+    // Fetch listings, bids and wins in parallel
     const [listingsResponse, bidsResponse, winsResponse] =
       await Promise.all([
         getProfileListings(user.name),
-        getProfileBids(user.name), 
+        getProfileBids(user.name),
         getProfileWins(user.name)
       ]);
 
-    // Calculate stats
     const myListings = listingsResponse.data.length;
     const myBids = bidsResponse.data.length;
     const totalWins = winsResponse.data?.length || 0;
-    const winRate = calculateWinRate(myBids, totalWins);
+    const auctionsBidOn = countAuctionsBidOn(bidsResponse.data);
+    const winRate = calculateWinRate(auctionsBidOn, totalWins);
     const activeBidsValue = calculateActiveBidsValue(bidsResponse.data);
 
     return {
       myListings,
       myBids,
       winRate,
-      activeBidsValue
+      activeBidsValue,
     };
   } catch (error) {
-    console.error('Error fetching stats:', error);
+    logError('Failed to fetch stats', error);
     return null;
   }
 }
 
-/**
- * Animate number counting effect
- * @param element - The element to animate
- * @param target - The target number
- * @param isCurrency - Whether to format as currency
- * @param duration - Animation duration in milliseconds
- */
 function animateNumber(
   element: HTMLElement,
   target: number,
@@ -159,19 +128,13 @@ function animateNumber(
     }
 
     if (isCurrency) {
-      element.textContent = formatCurrency(Math.floor(current));
+      element.textContent = formatCurrency(Math.floor(current), true);
     } else {
       element.textContent = new Intl.NumberFormat('en-US').format(Math.floor(current));
     }
   }, 16);
 }
 
-/**
- * Animate win rate percentage
- * @param element - The element to animate
- * @param target - The target percentage
- * @param duration - Animation duration in milliseconds
- */
 function animateWinRate(
   element: HTMLElement,
   target: number,
@@ -192,22 +155,18 @@ function animateWinRate(
   }, 16);
 }
 
-/**
- * Initialize stats bar component with dynamic data
- * Fetches data from API, renders the component, and animates numbers
- */
 export async function initStatsBar(): Promise<void> {
   const container = document.getElementById('stats-bar-container');
   if (!container) return;
 
-  // Check if user is logged in
+  // Hide stats for guests
   const user = getCurrentUser();
   if (!user) {
-    container.innerHTML = ''; // Don't show stats for guests
+    container.innerHTML = '';
     return;
   }
 
-  // Show loading state
+  // Loading state
   container.innerHTML = `
     <div class="mb-20 grid grid-cols-2 gap-6 md:grid-cols-4">
       ${Array(4)
@@ -228,24 +187,21 @@ export async function initStatsBar(): Promise<void> {
     </div>
   `;
 
-  // Fetch data
   const data = await fetchStats();
 
   if (!data) {
-    container.innerHTML = ''; // Hide on error
+    container.innerHTML = '';
     return;
   }
 
-  // Render component
   container.innerHTML = renderStatsBar(data);
 
-  // Animate numbers if IntersectionObserver is available
+  // Animate counters when the bar scrolls into view
   if ('IntersectionObserver' in window) {
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            // Animate each stat
             const myListingsEl = container.querySelector(
               '[data-stat="myListings"]'
             ) as HTMLElement;
@@ -275,11 +231,7 @@ export async function initStatsBar(): Promise<void> {
   }
 }
 
-/**
- * Update stats bar with new data
- * Useful for real-time updates or after user actions
- * @param data - New stats data
- */
+// Update stats bar in place with new data (used after user actions)
 export function updateStatsBar(data: StatsData): void {
   const container = document.getElementById('stats-bar-container');
   if (!container) return;
@@ -312,7 +264,7 @@ export function updateStatsBar(data: StatsData): void {
 
   if (activeBidsValueEl) {
     const currentValue = parseInt(
-      activeBidsValueEl.textContent?.replace(/[$,]/g, '') || '0'
+      activeBidsValueEl.textContent?.replace(/[^\d]/g, '') || '0'
     );
     if (currentValue !== data.activeBidsValue) {
       animateNumber(activeBidsValueEl, data.activeBidsValue, true, 500);
@@ -320,10 +272,7 @@ export function updateStatsBar(data: StatsData): void {
   }
 }
 
-/**
- * Refresh stats bar - fetches and updates with latest data
- * Useful after creating a listing, placing a bid, etc.
- */
+// Refetch and update — call after creating a listing, placing a bid, etc.
 export async function refreshStatsBar(): Promise<void> {
   const data = await fetchStats();
   if (data) {

--- a/src/pages/Collection.ts
+++ b/src/pages/Collection.ts
@@ -6,6 +6,7 @@ import {
 } from '../components/CollectionCard';
 import { renderPagination } from '../components/PaginationComponent';
 import { getListings } from '../api/listings';
+import { logError } from '../utils/logger';
 import type { Listing } from '../types/api';
 
 // State management
@@ -34,9 +35,6 @@ let currentFilters: FilterState = {
 let allListings: Listing[] = [];
 let filteredListings: Listing[] = [];
 
-/**
- * Listen to navbar filter events
- */
 function listenToNavbarFilters(): void {
   // Category filter from navbar
   document.addEventListener('categoryFilterChange', ((e: CustomEvent) => {
@@ -68,9 +66,6 @@ function listenToNavbarFilters(): void {
   }) as EventListener);
 }
 
-/**
- * Initialize filter event listeners
- */
 function initializeFilters(): void {
   // View toggle (grid vs list)
   const gridViewBtn = document.getElementById('grid-view-btn');
@@ -147,9 +142,6 @@ function initializeFilters(): void {
   }
 }
 
-/**
- * Initialize collection page
- */
 export async function initCollectionPage(): Promise<void> {
   // Render header and footer
   await renderHeader();
@@ -165,15 +157,11 @@ export async function initCollectionPage(): Promise<void> {
   loadListings();
 }
 
-/**
- * Load listings from API
- */
 async function loadListings(): Promise<void> {
   try {
     // Show loading skeletons
     showCollectionCardSkeletons(24, 'collection-cards-grid');
 
-    // Fetch listings with filters (reduced from 100 to 50 for better performance)
     const response = await getListings({
       limit: 50,
       _seller: true,
@@ -188,14 +176,11 @@ async function loadListings(): Promise<void> {
       updateStats();
     }
   } catch (error) {
-    console.error('Error loading listings:', error);
+    logError('Failed to load collection listings', error);
     showError('Failed to load listings. Please try again later.');
   }
 }
 
-/**
- * Apply filters to listings
- */
 function applyFilters(): void {
   let filtered = [...allListings];
 
@@ -267,9 +252,6 @@ function applyFilters(): void {
   updateResultsInfo();
 }
 
-/**
- * Update results information display
- */
 function updateResultsInfo(): void {
   const resultsCount = document.getElementById('results-count');
   const resultsRange = document.getElementById('results-range');
@@ -299,9 +281,6 @@ function updateResultsInfo(): void {
   }
 }
 
-/**
- * Update hero stats
- */
 function updateStats(): void {
   const activeLotsCount = document.getElementById('active-lots-count');
   const endingSoonCount = document.getElementById('ending-soon-count');
@@ -329,9 +308,6 @@ function updateStats(): void {
 }
 
 
-/**
- * Show error message
- */
 function showError(message: string): void {
   const container = document.getElementById('collection-cards-grid');
   if (!container) return;

--- a/src/pages/Home.ts
+++ b/src/pages/Home.ts
@@ -9,6 +9,7 @@ import { toast } from '../components/Toast';
 import { isLoggedIn } from '../utils/auth';
 import { formatTimeRemaining } from '../utils/formatDate';
 import { addStructuredData, generateWebsiteStructuredData, generateOrganizationStructuredData } from '../utils/seo';
+import { logError } from '../utils/logger';
 import type { Listing } from '../types/api';
 import {
   renderSearchField,
@@ -47,9 +48,6 @@ let catalogState: CatalogState = {
   itemsPerPage: 12,
 };
 
-/**
- * Listen to navbar filter events
- */
 function listenToNavbarFilters(): void {
   // Category filter from navbar
   document.addEventListener('categoryFilterChange', ((e: CustomEvent) => {
@@ -85,9 +83,6 @@ function listenToNavbarFilters(): void {
   }) as EventListener);
 }
 
-/**
- * Initialize sticky filter bar with scroll detection and event handlers
- */
 function initStickyFilterBar(): void {
   const stickyBar = document.getElementById('sticky-catalog-filters');
   const catalogSection = document.querySelector('#catalog-cards')?.parentElement;
@@ -169,9 +164,6 @@ function initStickyFilterBar(): void {
   initStickyFilterEvents();
 }
 
-/**
- * Initialize event listeners for sticky filter bar
- */
 function initStickyFilterEvents(): void {
   // Initialize search field using component
   initSearchField('sticky-search-input', 300);
@@ -207,9 +199,6 @@ function initStickyFilterEvents(): void {
   }
 }
 
-/**
- * Sync sticky filter bar with current state
- */
 function syncStickyFiltersWithState(): void {
   // Sync search input using component
   setSearchFieldValue('sticky-search-input', catalogState.search);
@@ -224,9 +213,6 @@ function syncStickyFiltersWithState(): void {
   setSortValue('sticky-sort-select', catalogState.sort, catalogState.sortOrder);
 }
 
-/**
- * Initialize home page
- */
 async function initHomePage(): Promise<void> {
   // Render header and footer (header includes guest banner)
   await renderHeader();
@@ -249,9 +235,6 @@ async function initHomePage(): Promise<void> {
   await loadAllData();
 }
 
-/**
- * Setup create listing button behavior
- */
 function setupCreateListingButton(): void {
   const createListingBtn = document.getElementById('create-listing-btn');
   if (!createListingBtn) return;
@@ -267,12 +250,8 @@ function setupCreateListingButton(): void {
   }
 }
 
-/**
- * Load all data for the home page
- */
 async function loadAllData(): Promise<void> {
   try {
-    // Fetch listings (reduced from 100 to 50 for better initial load performance)
     const response = await getListings({
       limit: 50,
       _seller: true,
@@ -294,15 +273,12 @@ async function loadAllData(): Promise<void> {
       showNoListingsMessage();
     }
   } catch (error) {
-    console.error('Error loading data:', error);
+    logError('Failed to load home page data', error);
     toast.error('Failed to load listings. Please refresh the page.');
     showErrorInSections();
   }
 }
 
-/**
- * Show no listings message in all sections
- */
 function showNoListingsMessage(): void {
   const noDataHTML = `
     <div class="col-span-full text-center py-12">
@@ -329,9 +305,6 @@ function showNoListingsMessage(): void {
   }
 }
 
-/**
- * Show error message in all sections
- */
 function showErrorInSections(): void {
   const errorHTML = `
     <div class="col-span-full text-center py-12">
@@ -355,9 +328,6 @@ function showErrorInSections(): void {
   });
 }
 
-/**
- * Render Hero Section with mosaic and stats
- */
 function renderHeroSection(): void {
   const heroMosaic = document.getElementById('hero-mosaic');
   const heroActiveCount = document.getElementById('hero-active-count');
@@ -483,9 +453,7 @@ function renderHeroSection(): void {
   heroMosaic.innerHTML = mosaicHTML;
 }
 
-/**
- * Render Trending Section (listings with most bids)
- */
+// Trending = active listings sorted by bid count
 function renderTrendingSection(): void {
   const now = new Date();
   const activeListings = allListings.filter(listing => new Date(listing.endsAt) > now);
@@ -503,9 +471,6 @@ function renderTrendingSection(): void {
   }, 300);
 }
 
-/**
- * Render New Listings Section (newest listings)
- */
 function renderNewListingsSection(): void {
   const now = new Date();
   const activeListings = allListings.filter(listing => new Date(listing.endsAt) > now);
@@ -522,9 +487,7 @@ function renderNewListingsSection(): void {
   }, 400);
 }
 
-/**
- * Render Ending Soon Section (listings ending in next 24 hours)
- */
+// Listings ending in the next 24 hours
 function renderEndingSoonSection(): void {
   const now = new Date();
   const tomorrow = new Date(now);
@@ -543,16 +506,10 @@ function renderEndingSoonSection(): void {
   }, 500);
 }
 
-/**
- * Render Catalog Section with filters
- */
 function renderCatalogSection(): void {
   applyCatalogFilters();
 }
 
-/**
- * Apply catalog filters
- */
 function applyCatalogFilters(): void {
   let filtered = [...allListings];
 

--- a/src/pages/ListingCreate.ts
+++ b/src/pages/ListingCreate.ts
@@ -3,11 +3,11 @@ import { renderFooter } from '../components/Footer';
 import { renderBreadcrumbInContainer, BREADCRUMB_PRESETS } from '../components/Breadcrumb';
 import { createListing } from '../api/listings';
 import { protectedRoute } from '../utils/auth';
+import { toast } from '../components/Toast';
+import { logError } from '../utils/logger';
+import { getErrorMessage } from '../utils/errorHandling';
 import type { CreateListingData } from '../types/api';
 
-/**
- * Initialize listing create page
- */
 export async function initListingCreatePage(): Promise<void> {
   // Render header and footer
   await renderHeader();
@@ -28,9 +28,6 @@ export async function initListingCreatePage(): Promise<void> {
   renderCreateForm();
 }
 
-/**
- * Render the create listing form with live preview
- */
 function renderCreateForm(): void {
   const container = document.getElementById('create-listing-content');
   if (!container) return;
@@ -220,9 +217,6 @@ function renderCreateForm(): void {
   initFormHandlers();
 }
 
-/**
- * Initialize form handlers
- */
 function initFormHandlers(): void {
   const form = document.getElementById('create-listing-form') as HTMLFormElement;
   const titleInput = document.getElementById('title') as HTMLInputElement;
@@ -338,9 +332,6 @@ function initFormHandlers(): void {
   }
 }
 
-/**
- * Handle form submission
- */
 async function handleFormSubmit(event: Event): Promise<void> {
   event.preventDefault();
 
@@ -395,14 +386,8 @@ async function handleFormSubmit(event: Event): Promise<void> {
     // Redirect to the created listing
     window.location.href = `/listing.html?id=${response.data.id}`;
   } catch (error) {
-    console.error('Error creating listing:', error);
-
-    let errorMessage = 'Failed to create listing. Please try again.';
-    if (error instanceof Error) {
-      errorMessage = error.message;
-    }
-
-    alert(errorMessage);
+    logError('Failed to create listing', error);
+    toast.error(getErrorMessage(error, 'Failed to create listing. Please try again.'));
 
     // Re-enable submit button
     submitBtn.disabled = false;

--- a/src/pages/ListingDetail.ts
+++ b/src/pages/ListingDetail.ts
@@ -18,6 +18,7 @@ import {
 import { APP_BASE_URL } from '../utils/constants';
 import { logError } from '../utils/logger';
 import { getErrorMessage } from '../utils/errorHandling';
+import { isWatched, toggleWatched } from '../utils/storage';
 import type { Listing } from '../types/api';
 import { generateResponsiveImageAttrs } from '../utils/imageOptimization';
 
@@ -25,9 +26,6 @@ import { generateResponsiveImageAttrs } from '../utils/imageOptimization';
 let currentListing: Listing | null = null;
 let countdownInterval: number | null = null;
 
-/**
- * Initialize the listing detail page
- */
 async function init() {
   // Render header and footer
   await renderHeader();
@@ -80,9 +78,6 @@ async function init() {
   });
 }
 
-/**
- * Update dynamic SEO meta tags for the listing
- */
 function updateDynamicSEO(listing: Listing) {
   // Update page title
   const title = `${listing.title} - Auction Listing | Aucto`;
@@ -106,9 +101,6 @@ function updateDynamicSEO(listing: Listing) {
   addStructuredData(generateListingStructuredData(listing));
 }
 
-/**
- * Show error message
- */
 function showError(message: string) {
   const main = document.querySelector('main');
   if (main) {
@@ -129,9 +121,6 @@ function showError(message: string) {
   }
 }
 
-/**
- * Render breadcrumb navigation
- */
 function renderBreadcrumb(listing: Listing) {
   renderBreadcrumbInContainer({
     containerId: 'breadcrumb-nav',
@@ -139,9 +128,6 @@ function renderBreadcrumb(listing: Listing) {
   });
 }
 
-/**
- * Render listing header
- */
 function renderListingHeader(listing: Listing) {
   const header = document.getElementById('listing-header');
   if (!header) return;
@@ -187,9 +173,6 @@ function renderListingHeader(listing: Listing) {
   `;
 }
 
-/**
- * Render media gallery
- */
 function renderMediaGallery(listing: Listing) {
   const gallery = document.getElementById('media-gallery');
   if (!gallery) return;
@@ -265,9 +248,6 @@ function renderMediaGallery(listing: Listing) {
   initGallery();
 }
 
-/**
- * Initialize gallery interactions
- */
 function initGallery() {
   const thumbnails = document.querySelectorAll('.thumbnail-btn');
   const mainImage = document.getElementById('main-image') as HTMLImageElement;
@@ -295,9 +275,6 @@ function initGallery() {
   });
 }
 
-/**
- * Render listing details
- */
 function renderListingDetails(listing: Listing) {
   const details = document.getElementById('listing-details');
   if (!details) return;
@@ -343,9 +320,6 @@ function renderListingDetails(listing: Listing) {
   `;
 }
 
-/**
- * Render bid panel
- */
 function renderBidPanel(listing: Listing) {
   const panel = document.getElementById('bid-panel');
   if (!panel) return;
@@ -457,9 +431,6 @@ function renderBidPanel(listing: Listing) {
   }
 }
 
-/**
- * Initialize bid form
- */
 function initBidForm() {
   const form = document.getElementById('bid-form') as HTMLFormElement;
   if (!form || !currentListing) return;
@@ -534,9 +505,6 @@ function initBidForm() {
   });
 }
 
-/**
- * Copy text to clipboard
- */
 function copyToClipboard(text: string) {
   if (navigator.clipboard) {
     navigator.clipboard.writeText(text).then(() => {
@@ -562,56 +530,47 @@ function copyToClipboard(text: string) {
   }
 }
 
-/**
- * Initialize quick action buttons (Watch & Share)
- */
 function initQuickActions(listing: Listing) {
   const watchBtn = document.getElementById('watch-btn');
   const shareBtn = document.getElementById('share-btn');
 
   // Watch button functionality
   if (watchBtn) {
-    // Check if listing is already watched (using localStorage)
-    const watchedListings = JSON.parse(localStorage.getItem('watchedListings') || '[]');
-    const isWatched = watchedListings.includes(listing.id);
-
-    // Update button state
-    if (isWatched) {
+    const renderWatching = (): void => {
       watchBtn.innerHTML = `
         <i class="fa-solid fa-bookmark text-sm"></i>
         <span>Watching</span>
       `;
       watchBtn.classList.add('bg-slate-900', 'text-white');
       watchBtn.classList.remove('bg-white', 'text-slate-700');
+      watchBtn.setAttribute('aria-pressed', 'true');
+    };
+
+    const renderUnwatched = (): void => {
+      watchBtn.innerHTML = `
+        <i class="fa-solid fa-bookmark text-sm"></i>
+        <span>Watch</span>
+      `;
+      watchBtn.classList.remove('bg-slate-900', 'text-white');
+      watchBtn.classList.add('bg-white', 'text-slate-700');
+      watchBtn.setAttribute('aria-pressed', 'false');
+    };
+
+    if (isWatched(listing.id)) {
+      renderWatching();
+    } else {
+      renderUnwatched();
     }
 
     watchBtn.addEventListener('click', () => {
-      const watchedListings = JSON.parse(localStorage.getItem('watchedListings') || '[]');
-      const index = watchedListings.indexOf(listing.id);
-
-      if (index > -1) {
-        // Remove from watchlist
-        watchedListings.splice(index, 1);
-        watchBtn.innerHTML = `
-          <i class="fa-solid fa-bookmark text-sm"></i>
-          <span>Watch</span>
-        `;
-        watchBtn.classList.remove('bg-slate-900', 'text-white');
-        watchBtn.classList.add('bg-white', 'text-slate-700');
-        showToast('Removed from watchlist', 'info');
-      } else {
-        // Add to watchlist
-        watchedListings.push(listing.id);
-        watchBtn.innerHTML = `
-          <i class="fa-solid fa-bookmark text-sm"></i>
-          <span>Watching</span>
-        `;
-        watchBtn.classList.add('bg-slate-900', 'text-white');
-        watchBtn.classList.remove('bg-white', 'text-slate-700');
+      const nowWatched = toggleWatched(listing.id);
+      if (nowWatched) {
+        renderWatching();
         showToast('Added to watchlist', 'success');
+      } else {
+        renderUnwatched();
+        showToast('Removed from watchlist', 'info');
       }
-
-      localStorage.setItem('watchedListings', JSON.stringify(watchedListings));
     });
   }
 
@@ -645,13 +604,10 @@ function initQuickActions(listing: Listing) {
   }
 }
 
-/**
- * Render tags section
- */
 function renderTags(listing: Listing) {
   const tagsSection = document.getElementById('tags-section');
   if (!tagsSection) {
-    console.error('Tags section element not found!');
+    logError('Tags section element not found');
     return;
   }
 
@@ -689,9 +645,6 @@ function renderTags(listing: Listing) {
   `;
 }
 
-/**
- * Render bid history
- */
 function renderBidHistory(listing: Listing) {
   const history = document.getElementById('bid-history');
   if (!history) return;
@@ -745,9 +698,6 @@ function renderBidHistory(listing: Listing) {
   `;
 }
 
-/**
- * Render seller profile
- */
 function renderSellerProfile(listing: Listing) {
   const profile = document.getElementById('seller-profile');
   if (!profile) return;
@@ -816,9 +766,6 @@ function renderSellerProfile(listing: Listing) {
   `;
 }
 
-/**
- * Render listing meta
- */
 function renderListingMeta(listing: Listing) {
   const meta = document.getElementById('listing-meta');
   if (!meta) return;
@@ -876,9 +823,6 @@ function renderListingMeta(listing: Listing) {
   `;
 }
 
-/**
- * Start countdown timer
- */
 function startCountdown(endDate: string) {
   const updateCountdown = () => {
     const countdownDisplay = document.getElementById('countdown-display');

--- a/src/pages/ListingEdit.ts
+++ b/src/pages/ListingEdit.ts
@@ -10,9 +10,6 @@ import type { Listing, UpdateListingData } from '../types/api';
 
 let currentListing: Listing | null = null;
 
-/**
- * Initialize listing edit page
- */
 export async function initListingEditPage(): Promise<void> {
   // Render header and footer
   await renderHeader();
@@ -36,9 +33,6 @@ export async function initListingEditPage(): Promise<void> {
   await loadListingData(listingId);
 }
 
-/**
- * Load listing data from API
- */
 async function loadListingData(listingId: string): Promise<void> {
   const container = document.getElementById('edit-listing-content');
   if (!container) return;
@@ -70,14 +64,11 @@ async function loadListingData(listingId: string): Promise<void> {
     initializePreview();
     initializeDeleteModal(listingId);
   } catch (error) {
-    console.error('Error loading listing:', error);
+    logError('Failed to load listing for edit', error, { listingId });
     showError('Failed to load listing data. The listing may not exist or you may not have permission to edit it.');
   }
 }
 
-/**
- * Render the edit form with listing data
- */
 function renderEditForm(listing: Listing, hasBids: boolean): void {
   const container = document.getElementById('edit-listing-content');
   if (!container) return;
@@ -348,9 +339,6 @@ function renderEditForm(listing: Listing, hasBids: boolean): void {
   `;
 }
 
-/**
- * Initialize form event listeners
- */
 function initializeFormListeners(listingId: string, hasBids: boolean): void {
   const form = document.getElementById('editForm') as HTMLFormElement;
   if (!form) return;
@@ -415,14 +403,11 @@ function initializeFormListeners(listingId: string, hasBids: boolean): void {
         window.location.href = `/listing.html?id=${listingId}`;
       }, 1500);
     } catch (error: unknown) {
-      console.error('Error updating listing:', error);
-
       // Restore button state
       const submitButton = form.querySelector('button[type="submit"]') as HTMLButtonElement;
       submitButton.disabled = false;
       submitButton.innerHTML = '<i class="fa-solid fa-floppy-disk text-base"></i><span>Save changes</span>';
 
-      // Show error message
       logError('Failed to update listing', error, { listingId });
       const errorMessage = getErrorMessage(error, 'Failed to update listing. Please try again.');
       toast.error(errorMessage);
@@ -430,9 +415,6 @@ function initializeFormListeners(listingId: string, hasBids: boolean): void {
   });
 }
 
-/**
- * Initialize live preview updates
- */
 function initializePreview(): void {
   const titleInput = document.getElementById('title') as HTMLInputElement;
   const descriptionInput = document.getElementById('description') as HTMLTextAreaElement;
@@ -521,9 +503,6 @@ function initializePreview(): void {
   imageUrlsInput.addEventListener('input', updateImagePreviews);
 }
 
-/**
- * Initialize delete modal functionality
- */
 function initializeDeleteModal(listingId: string): void {
   const deleteButton = document.getElementById('deleteButton');
   const deleteModal = document.getElementById('deleteModal');
@@ -532,15 +511,18 @@ function initializeDeleteModal(listingId: string): void {
 
   if (!deleteButton || !deleteModal || !cancelDelete || !confirmDelete) return;
 
-  // Show modal
-  deleteButton.addEventListener('click', () => {
+  const openModal = (): void => {
     deleteModal.classList.remove('hidden');
-  });
+    deleteModal.classList.add('flex');
+  };
 
-  // Hide modal
-  cancelDelete.addEventListener('click', () => {
+  const closeModal = (): void => {
+    deleteModal.classList.remove('flex');
     deleteModal.classList.add('hidden');
-  });
+  };
+
+  deleteButton.addEventListener('click', openModal);
+  cancelDelete.addEventListener('click', closeModal);
 
   // Confirm deletion
   confirmDelete.addEventListener('click', async () => {
@@ -561,34 +543,26 @@ function initializeDeleteModal(listingId: string): void {
         window.location.href = '/profile.html';
       }, 1500);
     } catch (error: unknown) {
-      console.error('Error deleting listing:', error);
-
       // Restore button state
       const deleteBtn = confirmDelete as HTMLButtonElement;
       deleteBtn.disabled = false;
       deleteBtn.innerHTML = 'Delete Forever';
 
-      // Show error message
       logError('Failed to delete listing', error, { listingId });
       const errorMessage = getErrorMessage(error, 'Failed to delete listing. Please try again.');
       toast.error(errorMessage);
 
-      // Close modal
-      deleteModal.classList.add('hidden');
+      closeModal();
     }
   });
 
-  // Close modal on outside click
   deleteModal.addEventListener('click', (e) => {
     if (e.target === deleteModal) {
-      deleteModal.classList.add('hidden');
+      closeModal();
     }
   });
 }
 
-/**
- * Show error message
- */
 function showError(message: string): void {
   const container = document.getElementById('edit-listing-content');
   if (!container) return;

--- a/src/pages/Login.ts
+++ b/src/pages/Login.ts
@@ -7,11 +7,9 @@ import { renderHeader } from '../components/Navbar';
 import { renderFooter } from '../components/Footer';
 import { ApiErrorClass } from '../api/config';
 import { getListings } from '../api/listings';
+import { logError } from '../utils/logger';
 import type { Listing } from '../types/api';
 
-/**
- * Initialize login page
- */
 export async function initLoginPage(): Promise<void> {
   // Render header and footer
   await renderHeader();
@@ -23,7 +21,7 @@ export async function initLoginPage(): Promise<void> {
   // Get form element
   const form = document.getElementById('login-form') as HTMLFormElement;
   if (!form) {
-    console.error('Login form not found');
+    logError('Login form not found');
     return;
   }
 
@@ -46,22 +44,15 @@ export async function initLoginPage(): Promise<void> {
   initProductShowcase();
 }
 
-/**
- * Initialize product showcase with live data from API
- */
 async function initProductShowcase(): Promise<void> {
-  // Fetch and display real listings
   await loadDynamicListings();
 
-  // Refresh listings every 15 seconds
+  // Refresh every 15 seconds
   setInterval(() => {
     loadDynamicListings();
   }, 15000);
 }
 
-/**
- * Load dynamic listings from API and update showcase
- */
 async function loadDynamicListings(): Promise<void> {
   try {
     // Fetch latest listings with bids
@@ -76,14 +67,11 @@ async function loadDynamicListings(): Promise<void> {
       updateProductShowcase(response.data);
     }
   } catch (error) {
-    console.error('Failed to load dynamic listings:', error);
+    logError('Failed to load dynamic listings on login page', error);
     // Silently fail - keep existing content
   }
 }
 
-/**
- * Update product showcase with real listings
- */
 function updateProductShowcase(listings: Listing[]): void {
   // Update featured listing (main tile)
   if (listings[0]) {
@@ -99,9 +87,6 @@ function updateProductShowcase(listings: Listing[]): void {
   }
 }
 
-/**
- * Update the featured listing showcase
- */
 function updateFeaturedListing(listing: Listing): void {
   const article = document.querySelector('[data-tile="featured"]') as HTMLElement;
   if (!article) return;
@@ -136,9 +121,6 @@ function updateFeaturedListing(listing: Listing): void {
   }
 }
 
-/**
- * Update a small tile with listing data
- */
 function updateSmallTile(listing: Listing, tileId: string): void {
   const article = document.querySelector(`[data-tile="${tileId}"]`) as HTMLElement;
   if (!article) return;
@@ -188,9 +170,6 @@ function updateSmallTile(listing: Listing, tileId: string): void {
 }
 
 
-/**
- * Validate email field
- */
 function validateEmailField(input: HTMLInputElement): boolean {
   const email = input.value.trim();
 
@@ -208,9 +187,6 @@ function validateEmailField(input: HTMLInputElement): boolean {
   return true;
 }
 
-/**
- * Handle login form submission
- */
 async function handleLoginSubmit(e: Event): Promise<void> {
   e.preventDefault();
 
@@ -265,7 +241,7 @@ async function handleLoginSubmit(e: Event): Promise<void> {
     }, 1000);
 
   } catch (error) {
-    console.error('Login error:', error);
+    logError('Login failed', error);
 
     // Handle API errors
     if (error instanceof ApiErrorClass) {

--- a/src/pages/ProfilePage.ts
+++ b/src/pages/ProfilePage.ts
@@ -12,10 +12,10 @@ import type { Profile, Listing, Bid, UpdateProfileData } from '../types/api';
 import { formatDate, formatTimeRemaining } from '../utils/formatDate';
 import { isValidUrl } from '../utils/validation';
 import { showToast } from '../components/Toast';
+import { setUser } from '../utils/storage';
+import { logError } from '../utils/logger';
+import { getErrorMessage } from '../utils/errorHandling';
 
-/**
- * Initialize profile page
- */
 export async function initProfilePage(): Promise<void> {
   // Render header and footer
   await renderHeader();
@@ -57,9 +57,6 @@ export async function initProfilePage(): Promise<void> {
   }
 }
 
-/**
- * Update page header title and description
- */
 function updatePageHeader(title: string, description: string): void {
   const titleElement = document.getElementById('page-title');
   const descElement = document.getElementById('page-description');
@@ -73,9 +70,6 @@ function updatePageHeader(title: string, description: string): void {
   }
 }
 
-/**
- * Load profile data from API
- */
 async function loadProfileData(username: string, isOwnProfile: boolean): Promise<void> {
   const container = document.getElementById('profile-content');
   if (!container) return;
@@ -108,14 +102,11 @@ async function loadProfileData(username: string, isOwnProfile: boolean): Promise
     // Render profile
     renderProfile(profile, listings, bids, wins, isOwnProfile);
   } catch (error) {
-    console.error('Error loading profile:', error);
+    logError('Failed to load profile data', error);
     showError('Failed to load profile data');
   }
 }
 
-/**
- * Render complete profile
- */
 function renderProfile(
   profile: Profile,
   listings: Listing[],
@@ -146,9 +137,6 @@ function renderProfile(
   }
 }
 
-/**
- * Render profile hero section
- */
 function renderProfileHero(
   profile: Profile,
   activeListingsCount: number,
@@ -332,9 +320,6 @@ function renderProfileHero(
   `;
 }
 
-/**
- * Render about and settings section
- */
 function renderAboutAndSettings(profile: Profile, isOwnProfile: boolean): string {
   return `
     <section>
@@ -459,9 +444,6 @@ function renderAboutAndSettings(profile: Profile, isOwnProfile: boolean): string
   `;
 }
 
-/**
- * Render active listings section
- */
 function renderActiveListings(listings: Listing[], isOwnProfile: boolean): string {
   if (listings.length === 0) {
     return `
@@ -533,13 +515,12 @@ function renderActiveListings(listings: Listing[], isOwnProfile: boolean): strin
   `;
 }
 
-/**
- * Render listing card
- */
 function renderListingCard(listing: Listing, isOwnProfile: boolean): string {
   const imageUrl = listing.media?.[0]?.url || '';
   const bidsCount = listing._count?.bids || 0;
-  const highestBid = listing.bids?.[listing.bids.length - 1]?.amount || 0;
+  const highestBid = listing.bids?.length
+    ? Math.max(...listing.bids.map((b) => b.amount))
+    : 0;
   const tag = listing.tags?.[0] || 'General';
   const timeRemaining = formatTimeRemaining(listing.endsAt);
 
@@ -609,9 +590,6 @@ function renderListingCard(listing: Listing, isOwnProfile: boolean): string {
   `;
 }
 
-/**
- * Render wins and bids section
- */
 function renderWinsAndBids(wins: Listing[], bids: Bid[]): string {
   return `
     <section>
@@ -664,11 +642,10 @@ function renderWinsAndBids(wins: Listing[], bids: Bid[]): string {
   `;
 }
 
-/**
- * Render win item
- */
 function renderWinItem(win: Listing): string {
-  const highestBid = win.bids?.[win.bids.length - 1]?.amount || 0;
+  const highestBid = win.bids?.length
+    ? Math.max(...win.bids.map((b) => b.amount))
+    : 0;
   const timeAgo = formatDate(win.endsAt);
 
   return `
@@ -690,9 +667,6 @@ function renderWinItem(win: Listing): string {
   `;
 }
 
-/**
- * Render bid item
- */
 function renderBidItem(bid: Bid): string {
   const timeAgo = formatDate(bid.created);
 
@@ -710,9 +684,6 @@ function renderBidItem(bid: Bid): string {
   `;
 }
 
-/**
- * Setup event listeners
- */
 function setupEventListeners(profile: Profile): void {
   const profileForm = document.getElementById('profile-form');
   if (profileForm) {
@@ -733,9 +704,6 @@ function setupEventListeners(profile: Profile): void {
   }
 }
 
-/**
- * Handle profile update
- */
 async function handleProfileUpdate(username: string): Promise<void> {
   const bioInput = document.getElementById('bio-input') as HTMLTextAreaElement;
   const avatarInput = document.getElementById('avatar-input') as HTMLInputElement;
@@ -796,8 +764,6 @@ async function handleProfileUpdate(username: string): Promise<void> {
         avatar: response.data.avatar,
         banner: response.data.banner,
       };
-      // Import setUser at the top if not already imported
-      const { setUser } = await import('../utils/storage');
       setUser(updatedUser);
     }
 
@@ -810,15 +776,8 @@ async function handleProfileUpdate(username: string): Promise<void> {
       await renderHeader();
     }, 1000);
   } catch (error) {
-    console.error('Error updating profile:', error);
-
-    // Show specific error message if available
-    let errorMessage = 'Failed to update profile';
-    if (error instanceof Error) {
-      errorMessage = error.message;
-    }
-
-    showToast(errorMessage, 'error');
+    logError('Failed to update profile', error, { username });
+    showToast(getErrorMessage(error, 'Failed to update profile'), 'error');
 
     // Re-enable button
     submitBtn.disabled = false;
@@ -827,9 +786,6 @@ async function handleProfileUpdate(username: string): Promise<void> {
 }
 
 
-/**
- * Show error message
- */
 function showError(message: string): void {
   const container = document.getElementById('profile-content');
   if (!container) return;

--- a/src/pages/Register.ts
+++ b/src/pages/Register.ts
@@ -13,23 +13,22 @@ import { renderHeader } from '../components/Navbar';
 import { renderFooter } from '../components/Footer';
 import { ApiErrorClass } from '../api/config';
 import { getListings } from '../api/listings';
+import { logError } from '../utils/logger';
 import type { Listing } from '../types/api';
 
-/**
- * Initialize register page
- */
+
 export async function initRegisterPage(): Promise<void> {
   // Render header and footer
   await renderHeader();
   renderFooter();
 
-  // Redirect if already authenticated
+
   redirectIfAuthenticated();
 
   // Get form element
   const form = document.getElementById('register-form') as HTMLFormElement;
   if (!form) {
-    console.error('Register form not found');
+    logError('Register form not found');
     return;
   }
 
@@ -70,9 +69,6 @@ export async function initRegisterPage(): Promise<void> {
   initProductShowcase();
 }
 
-/**
- * Initialize product showcase with live data from API
- */
 async function initProductShowcase(): Promise<void> {
   // Animate starter credits counter
   const starterCredits = document.getElementById('starter-credits');
@@ -109,9 +105,6 @@ async function initProductShowcase(): Promise<void> {
   }, 15000);
 }
 
-/**
- * Load dynamic listings from API and update showcase
- */
 async function loadDynamicListings(): Promise<void> {
   try {
     // Fetch latest listings with bids
@@ -126,14 +119,12 @@ async function loadDynamicListings(): Promise<void> {
       updateProductShowcase(response.data);
     }
   } catch (error) {
-    console.error('Failed to load dynamic listings:', error);
+    logError('Failed to load dynamic listings on register page', error);
     // Silently fail - keep existing content
   }
 }
 
-/**
- * Update product showcase with real listings
- */
+
 function updateProductShowcase(listings: Listing[]): void {
   // Update featured listing (main tile)
   if (listings[0]) {
@@ -149,9 +140,7 @@ function updateProductShowcase(listings: Listing[]): void {
   }
 }
 
-/**
- * Update the featured listing showcase
- */
+
 function updateFeaturedListing(listing: Listing): void {
   const article = document.querySelector('[data-tile="featured"]') as HTMLElement;
   if (!article) return;
@@ -179,14 +168,12 @@ function updateFeaturedListing(listing: Listing): void {
   }
 }
 
-/**
- * Update a small tile with listing data
- */
+
 function updateSmallTile(listing: Listing, tileId: string): void {
   const article = document.querySelector(`[data-tile="${tileId}"]`) as HTMLElement;
   if (!article) return;
 
-  // Update image
+
   const img = article.querySelector('img') as HTMLImageElement;
   if (img && listing.media && listing.media.length > 0) {
     img.src = listing.media[0].url;
@@ -216,9 +203,7 @@ function updateSmallTile(listing: Listing, tileId: string): void {
 }
 
 
-/**
- * Validate name field
- */
+
 function validateNameField(input: HTMLInputElement): boolean {
   const name = input.value.trim();
 
@@ -232,7 +217,7 @@ function validateNameField(input: HTMLInputElement): boolean {
     return false;
   }
 
-  // Only alphanumeric and underscore
+
   if (!/^[a-zA-Z0-9_]+$/.test(name)) {
     showFieldError('name', 'Name can only contain letters, numbers, and underscores');
     return false;
@@ -242,9 +227,7 @@ function validateNameField(input: HTMLInputElement): boolean {
   return true;
 }
 
-/**
- * Validate email field
- */
+
 function validateEmailField(input: HTMLInputElement): boolean {
   const email = input.value.trim();
 
@@ -262,9 +245,7 @@ function validateEmailField(input: HTMLInputElement): boolean {
   return true;
 }
 
-/**
- * Validate password field
- */
+
 function validatePasswordField(input: HTMLInputElement): boolean {
   const password = input.value;
 
@@ -282,9 +263,7 @@ function validatePasswordField(input: HTMLInputElement): boolean {
   return true;
 }
 
-/**
- * Validate confirm password field
- */
+
 function validateConfirmPasswordField(
   passwordInput: HTMLInputElement,
   confirmInput: HTMLInputElement
@@ -306,9 +285,7 @@ function validateConfirmPasswordField(
   return true;
 }
 
-/**
- * Update password strength indicator
- */
+
 function updatePasswordStrength(password: string): void {
   const strengthIndicator = document.getElementById('password-strength');
   if (!strengthIndicator) return;
@@ -346,9 +323,7 @@ function updatePasswordStrength(password: string): void {
   strengthIndicator.textContent = `Password strength: ${message}`;
 }
 
-/**
- * Handle register form submission
- */
+
 async function handleRegisterSubmit(e: Event): Promise<void> {
   e.preventDefault();
 
@@ -359,10 +334,10 @@ async function handleRegisterSubmit(e: Event): Promise<void> {
   const email = (formData.get('email') as string).trim();
   const password = formData.get('password') as string;
 
-  // Clear previous errors
+
   clearFormErrors('register-form');
 
-  // Validate all fields
+
   const nameInput = document.getElementById('name') as HTMLInputElement;
   const emailInput = document.getElementById('email') as HTMLInputElement;
   const passwordInput = document.getElementById('password') as HTMLInputElement;
@@ -377,20 +352,20 @@ async function handleRegisterSubmit(e: Event): Promise<void> {
 
   if (!isValid) return;
 
-  // Get submit button
+
   const submitBtn = form.querySelector('button[type="submit"]') as HTMLButtonElement;
   if (!submitBtn) return;
 
-  // Disable button and show loading state
+
   const originalBtnText = submitBtn.innerHTML;
   submitBtn.disabled = true;
   submitBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i> Creating Account...';
 
   try {
-    // Call register API
+ 
     await register({ name, email, password });
 
-    // Show success message
+  
     toast.success('Account created successfully! Redirecting to login...');
 
     // Redirect to login after short delay
@@ -399,7 +374,7 @@ async function handleRegisterSubmit(e: Event): Promise<void> {
     }, 2000);
 
   } catch (error) {
-    console.error('Registration error:', error);
+    logError('Registration failed', error);
 
     // Handle API errors
     if (error instanceof ApiErrorClass) {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,25 +1,16 @@
-import { getUser, isAuthenticated, isTokenExpired } from './storage';
-import { showSessionExpiredMessage } from './authLoader';
+import { getUser, isAuthenticated } from './storage';
+import { logError } from './logger';
 import type { User } from '../types/api';
 
-/**
- * Check if user is logged in
- */
+
 export function isLoggedIn(): boolean {
   return isAuthenticated();
 }
 
-/**
- * Get the current logged-in user
- */
 export function getCurrentUser(): User | null {
   return getUser();
 }
 
-/**
- * Redirect if already authenticated
- * @param defaultUrl - Default URL to redirect to
- */
 export function redirectIfAuthenticated(
   defaultUrl: string = '/index.html'
 ): void {
@@ -30,12 +21,7 @@ export function redirectIfAuthenticated(
   }
 }
 
-/**
- * Route guard for protected pages
- * Checks authentication and redirects to login with return URL if not authenticated
- * @param options - Configuration options
- * @returns boolean - true if authenticated, false if redirected
- */
+// Route guard. Returns true if authenticated; otherwise redirects to login and returns false.
 export function protectedRoute(options?: {
   redirectUrl?: string;
   showError?: boolean;
@@ -43,13 +29,8 @@ export function protectedRoute(options?: {
   if (!isAuthenticated()) {
     const redirect = options?.redirectUrl || window.location.pathname + window.location.search;
 
-    // Show session expired message if token was expired
-    if (isTokenExpired()) {
-      showSessionExpiredMessage();
-    }
-
     if (options?.showError) {
-      console.error('Authentication required to access this page');
+      logError('Authentication required to access this page');
     }
 
     window.location.href = `/login.html?redirect=${encodeURIComponent(redirect)}`;
@@ -58,13 +39,7 @@ export function protectedRoute(options?: {
   return true;
 }
 
-/**
- * Route guard for pages that require ownership validation
- * Must be called after protectedRoute() to ensure user is logged in
- * @param ownerName - Resource owner's username
- * @param fallbackUrl - URL to redirect if user is not owner (default: home)
- * @returns boolean - true if user is owner, false if redirected
- */
+// Ownership guard. Call AFTER protectedRoute(). Redirects to fallback if user isn't the owner.
 export function requireOwnership(
   ownerName: string,
   fallbackUrl: string = '/index.html'
@@ -72,7 +47,10 @@ export function requireOwnership(
   const user = getCurrentUser();
 
   if (!user || user.name !== ownerName) {
-    console.error('You do not have permission to access this resource');
+    logError('You do not have permission to access this resource', undefined, {
+      ownerName,
+      currentUser: user?.name,
+    });
     window.location.href = fallbackUrl;
     return false;
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,11 +1,5 @@
-/**
- * Centralized logging utility
- * Provides consistent error logging and can be extended for production monitoring
- */
+// Centralized logging. Swap the implementation here when wiring up an external monitor.
 
-/**
- * Log levels
- */
 export const LogLevel = {
   ERROR: 'error',
   WARN: 'warn',
@@ -15,52 +9,21 @@ export const LogLevel = {
 
 export type LogLevel = typeof LogLevel[keyof typeof LogLevel];
 
-/**
- * Logger configuration
- */
-interface LoggerConfig {
-  enabled: boolean;
-  level: LogLevel;
-  environment: 'development' | 'production';
-}
-
-/**
- * Default logger configuration
- */
-const config: LoggerConfig = {
-  enabled: true,
-  level: LogLevel.INFO,
-  environment: import.meta.env.MODE === 'production' ? 'production' : 'development',
-};
-
-/**
- * Format log message with timestamp and context
- */
 function formatMessage(level: LogLevel, message: string, context?: Record<string, unknown>): string {
   const timestamp = new Date().toISOString();
   const contextStr = context ? `\n${JSON.stringify(context, null, 2)}` : '';
   return `[${timestamp}] [${level.toUpperCase()}] ${message}${contextStr}`;
 }
 
-/**
- * Log error messages
- * In production, this could send to an error tracking service (e.g., Sentry)
- */
+// Single entry point for error logging across the app.
 export function logError(message: string, error?: Error | unknown, context?: Record<string, unknown>): void {
-  if (!config.enabled) return;
-
-  const errorDetails = error instanceof Error ? {
-    name: error.name,
-    message: error.message,
-    stack: error.stack,
-  } : { error };
+  const errorDetails = error instanceof Error
+    ? { name: error.name, message: error.message, stack: error.stack }
+    : error !== undefined
+      ? { error }
+      : {};
 
   const fullContext = { ...context, ...errorDetails };
-
-  if (config.environment === 'development') {
-    console.error(formatMessage(LogLevel.ERROR, message, fullContext));
-  } else {
-    console.error(formatMessage(LogLevel.ERROR, message, fullContext));
-  }
+  console.error(formatMessage(LogLevel.ERROR, message, fullContext));
 }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,32 +1,20 @@
 import type { User } from '../types/api';
 
-/**
- * Get the authentication token from localStorage
- */
 export function getToken(): string | null {
   return localStorage.getItem('token');
 }
 
-/**
- * Set the authentication token in localStorage
- * Also stores the timestamp when the token was set
- */
+// Stores the token plus a timestamp used by isTokenExpired (client-side 7-day expiry).
 export function setToken(token: string): void {
   localStorage.setItem('token', token);
   localStorage.setItem('tokenTimestamp', Date.now().toString());
 }
 
-/**
- * Remove the authentication token from localStorage
- */
 export function removeToken(): void {
   localStorage.removeItem('token');
   localStorage.removeItem('tokenTimestamp');
 }
 
-/**
- * Get the current user from localStorage
- */
 export function getUser(): User | null {
   const userStr = localStorage.getItem('user');
   if (!userStr) return null;
@@ -38,46 +26,30 @@ export function getUser(): User | null {
   }
 }
 
-/**
- * Set the current user in localStorage
- */
 export function setUser(user: User): void {
   localStorage.setItem('user', JSON.stringify(user));
 }
 
-/**
- * Remove the current user from localStorage
- */
 export function removeUser(): void {
   localStorage.removeItem('user');
 }
 
-/**
- * Clear all authentication data from localStorage
- */
 export function clearAuth(): void {
   removeToken();
   removeUser();
 }
 
-/**
- * Get the token timestamp from localStorage
- */
 export function getTokenTimestamp(): number | null {
   const timestamp = localStorage.getItem('tokenTimestamp');
   return timestamp ? parseInt(timestamp, 10) : null;
 }
 
-/**
- * Check if the token has expired
- * Tokens are considered expired after 7 days
- */
+// Client-side expiry: tokens go stale after 7 days.
 export function isTokenExpired(): boolean {
   const token = getToken();
   const timestamp = getTokenTimestamp();
 
-  
-  // This handles race conditions during login
+  // Token written but timestamp not yet flushed (login race) — treat as fresh.
   if (token && !timestamp) return false;
 
   if (!token || !timestamp) return true;
@@ -88,19 +60,47 @@ export function isTokenExpired(): boolean {
   return now - timestamp > sevenDaysInMs;
 }
 
-/**
- * Check if user is authenticated and token is not expired
- */
 export function isAuthenticated(): boolean {
   const hasToken = !!getToken();
 
   if (!hasToken) return false;
-
-  // Check if token is expired
   if (isTokenExpired()) {
     clearAuth();
     return false;
   }
 
+  return true;
+}
+
+const WATCHLIST_KEY = 'watchedListings';
+
+export function getWatchedListings(): string[] {
+  try {
+    const raw = localStorage.getItem(WATCHLIST_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isWatched(listingId: string): boolean {
+  return getWatchedListings().includes(listingId);
+}
+
+// Returns the new watched state (true = now in watchlist).
+export function toggleWatched(listingId: string): boolean {
+  const list = getWatchedListings();
+  const index = list.indexOf(listingId);
+  if (index >= 0) {
+    list.splice(index, 1);
+    localStorage.setItem(WATCHLIST_KEY, JSON.stringify(list));
+    return false;
+  }
+  list.push(listingId);
+  localStorage.setItem(WATCHLIST_KEY, JSON.stringify(list));
   return true;
 }


### PR DESCRIPTION
## Bug fixes + dead-code cleanup

- **Branch**: `refactor/pr-1-bug-fixes`
- **Date**: 2026-04-28
- **Scope**: pure correctness; no intended visual changes
- **Files touched**: 20 (`src/`) — 252 insertions, 235 deletions

### Bugs fixed

| Bug | Location | Fix |
| --- | --- | --- |
| Delete confirmation modal rendered top-left, not centred | `listing-edit.html:74` markup + `src/pages/ListingEdit.ts` JS | Toggle `hidden` ↔ `flex` symmetrically; extracted `openModal`/`closeModal` helpers |
| "Highest bid" on profile cards used the last bid in the array, not the max | `src/pages/ProfilePage.ts:542,671` (`renderListingCard`, `renderWinItem`) | `Math.max(...bids.map(b => b.amount))` |
| StatsBar formatted credits as USD ($) | `src/components/StatsBar.ts:21–27` | Removed local USD formatter, imported shared `formatCurrency(amount, true)` from `src/utils/formatCurrency.ts` |
| StatsBar win-rate divided wins by total bids (multiple bids on same listing inflate denominator) | `src/components/StatsBar.ts` `calculateWinRate` | New helper `countAuctionsBidOn(bids)` counts unique listing IDs; rate is `wins / unique-auctions-bid-on`, capped at 100% |
| `CollectionCard` favourite (heart) button was visual-only — toggled SVG fill but never persisted | `src/components/CollectionCard.ts` | Wired to new `toggleWatched()` storage helper; initial render reads `isWatched()` so state survives reloads |
| `ListingDetail` "Watch" button persisted via raw `localStorage.getItem('watchedListings')` access (only place in app doing this) | `src/pages/ListingDetail.ts:568–615` | Refactored onto the shared storage helpers; the watchlist in localStorage is now managed in one place |
| `ListingCreate` used native `alert(errorMessage)` — only file in codebase doing so | `src/pages/ListingCreate.ts:405` | `toast.error(getErrorMessage(error, …))` |

### Architectural cleanup

- `src/utils/storage.ts` — new exports: `getWatchedListings()`, `isWatched(listingId)`, `toggleWatched(listingId)` (returns new state). Single `WATCHLIST_KEY` constant. Cleaned up an orphan blank line + clarified the login-race comment.
- `src/api/config.ts` — removed direct `localStorage.getItem('token')`; now goes through `getToken()` from `storage.ts` (was the only direct localStorage read outside the storage module).
- `src/utils/auth.ts` — removed unreachable `if (isTokenExpired())` branch in `protectedRoute()`; `isAuthenticated()` already calls `clearAuth()` when expired, so by the time `protectedRoute` checks, the timestamp is gone and `isTokenExpired()` returns `false`. The 401 path in `apiClient` still handles real session expiry. Removed the now-unused `showSessionExpiredMessage` import.
- `src/pages/ProfilePage.ts` — hoisted `import { setUser }` to the top instead of `await import(...)` inside the submit handler.
- `src/components/Newsletter.ts` — removed locally redefined `isValidEmail`; imports shared util from `src/utils/validation.ts`.
- `src/utils/logger.ts` — collapsed identical dev/prod branches into a single call. The function is still the central entry point; swap implementation here when wiring an external monitor.
- `src/pages/ListingEdit.ts` — removed redundant `console.error` calls that ran alongside `logError` in the same catch blocks.
