### PR TITLE
refactor: design tokens via CSS variables and brand-color corrections

### DIFF
--- a/collection.html
+++ b/collection.html
@@ -82,7 +82,7 @@
   </head>
   <body class="antialiased bg-aucto-bg" data-page-type="browse">
     <!-- Skip Navigation Link -->
-    <a href="#catalog-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid #1e293b">Skip to main content</a>
+    <a href="#catalog-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid var(--aucto-border-dark)">Skip to main content</a>
 
     <!-- Header (rendered by JavaScript) -->
     <div id="header"></div>
@@ -117,7 +117,7 @@
             <div class="flex gap-3">
               <div
                 class="bg-slate-800 px-5 py-3 min-w-[100px] text-center"
-                style="border: 3px solid #334155"
+                style="border: 3px solid var(--aucto-border-mid)"
               >
                 <div class="mb-0.5 text-2xl font-bold text-white" id="active-lots-count">
                   ---
@@ -144,7 +144,7 @@
               <button
                 id="refresh-listings-btn"
                 class="inline-flex items-center gap-2 px-4 py-3 text-xs font-bold tracking-[0.18em] uppercase bg-white text-slate-900 hover:bg-slate-100 transition-colors"
-                style="border: 3px solid #334155"
+                style="border: 3px solid var(--aucto-border-mid)"
                 title="Refresh listings"
               >
                 <i class="text-sm fa-solid fa-rotate"></i>
@@ -153,7 +153,7 @@
               <button
                 id="clear-filters-btn"
                 class="inline-flex items-center gap-2 px-4 py-3 text-xs font-bold tracking-[0.18em] uppercase bg-slate-800 text-slate-300 hover:bg-slate-700 transition-colors"
-                style="border: 3px solid #334155"
+                style="border: 3px solid var(--aucto-border-mid)"
                 title="Clear all filters"
               >
                 <i class="text-sm fa-solid fa-filter-circle-xmark"></i>
@@ -178,7 +178,7 @@
         <!-- Results Header -->
         <div
           class="flex flex-wrap items-center justify-between gap-6 p-6 mb-8 bg-white"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
         >
           <div>
             <h2 class="mb-2 text-3xl font-bold text-slate-900">
@@ -199,7 +199,7 @@
               <button
                 id="grid-view-btn"
                 class="flex items-center gap-2 px-4 py-3 text-xs font-bold text-white transition-all bg-slate-900"
-                style="border: 3px solid #1e293b"
+                style="border: 3px solid var(--aucto-border-dark)"
                 title="Grid view"
               >
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -215,7 +215,7 @@
               <button
                 id="list-view-btn"
                 class="flex items-center gap-2 px-4 py-3 text-xs font-bold transition-all bg-white text-slate-700 hover:bg-slate-50"
-                style="border: 3px solid #334155"
+                style="border: 3px solid var(--aucto-border-mid)"
                 title="List view"
               >
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -282,7 +282,7 @@
             <div class="flex flex-wrap justify-center gap-3 mb-12">
               <button
                 class="flex items-center gap-2 px-8 py-3 text-sm font-bold tracking-wide transition-all bg-white text-slate-900 hover:bg-slate-100"
-                style="border: 3px solid #334155"
+                style="border: 3px solid var(--aucto-border-mid)"
               >
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path
@@ -296,7 +296,7 @@
               </button>
               <button
                 class="flex items-center gap-2 px-8 py-3 text-sm font-bold tracking-wide text-white transition-all bg-slate-800 hover:bg-slate-700"
-                style="border: 3px solid #334155"
+                style="border: 3px solid var(--aucto-border-mid)"
               >
                 <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
   </head>
   <body class="antialiased bg-aucto-bg" data-page-type="browse">
     <!-- Skip Navigation Link -->
-    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid #1e293b">Skip to main content</a>
+    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid var(--aucto-border-dark)">Skip to main content</a>
 
     <!-- Header (rendered by JavaScript) -->
     <div id="header"></div>
@@ -106,13 +106,13 @@
       <section class="px-6 py-10 mx-auto max-w-7xl md:px-8 md:py-14">
         <div
           class="p-8 bg-white md:p-10 lg:p-12"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
         >
           <div class="grid grid-cols-1 gap-10 lg:grid-cols-[3fr,2fr] lg:gap-12">
             <!-- Left: context + CTA -->
             <div class="flex flex-col justify-center">
               <div class="flex items-center gap-4 mb-6">
-                <div class="h-0.5 w-20 bg-red-700"></div>
+                <div class="h-0.5 w-20 bg-aucto-red"></div>
                 <span
                   class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500"
                 >
@@ -135,7 +135,7 @@
                 <a
                   href="/collection.html"
                   class="inline-flex items-center gap-2 px-8 py-4 text-sm font-bold tracking-wide text-white bg-slate-900 hover:bg-slate-800"
-                  style="border: 3px solid #1e293b"
+                  style="border: 3px solid var(--aucto-border-dark)"
                 >
                   <i class="text-sm fa-solid fa-circle-play"></i>
                   View live auctions
@@ -143,7 +143,7 @@
                 <a
                   href="/listing-create.html"
                   class="inline-flex items-center gap-2 px-8 py-4 text-sm font-bold tracking-wide bg-white text-slate-900 hover:bg-slate-50"
-                  style="border: 3px solid #1e293b"
+                  style="border: 3px solid var(--aucto-border-dark)"
                   id="create-listing-btn"
                 >
                   <i class="text-sm fa-solid fa-plus"></i>
@@ -189,7 +189,7 @@
       <section class="px-6 py-10 mx-auto max-w-7xl md:px-8 md:py-14">
         <div class="mb-12">
           <div class="flex items-center gap-4 mb-8">
-            <div class="h-0.5 w-16 bg-red-700"></div>
+            <div class="h-0.5 w-16 bg-aucto-red"></div>
             <span
               class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500"
               >Hot Right Now</span
@@ -220,7 +220,7 @@
       <section class="px-6 py-10 mx-auto max-w-7xl md:px-8 md:py-14">
         <div class="mb-12">
           <div class="flex items-center gap-4 mb-8">
-            <div class="h-0.5 w-16 bg-red-700"></div>
+            <div class="h-0.5 w-16 bg-aucto-red"></div>
             <span
               class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500"
               >Fresh Inventory</span
@@ -251,7 +251,7 @@
       <section class="px-6 py-10 mx-auto max-w-7xl md:px-8 md:py-14">
         <div class="mb-12">
           <div class="flex items-center gap-4 mb-8">
-            <div class="h-0.5 w-16 bg-red-700"></div>
+            <div class="h-0.5 w-16 bg-aucto-red"></div>
             <span
               class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500"
               >Last Chance</span
@@ -276,7 +276,7 @@
       <section class="px-6 py-10 mx-auto max-w-7xl md:px-8 md:py-14">
         <div class="mb-12">
           <div class="flex items-center gap-4 mb-8">
-            <div class="h-0.5 w-16 bg-red-700"></div>
+            <div class="h-0.5 w-16 bg-aucto-red"></div>
             <span
               class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500"
               >Complete Collection</span

--- a/listing-create.html
+++ b/listing-create.html
@@ -67,7 +67,7 @@
   </head>
   <body class="antialiased bg-aucto-bg" data-page-type="user-content">
     <!-- Skip Navigation Link -->
-    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid #1e293b">Skip to main content</a>
+    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid var(--aucto-border-dark)">Skip to main content</a>
 
     <!-- Header (rendered by JavaScript) -->
     <div id="header"></div>

--- a/listing-edit.html
+++ b/listing-edit.html
@@ -67,7 +67,7 @@
   </head>
   <body class="antialiased bg-aucto-bg" data-page-type="user-content">
     <!-- Skip Navigation Link -->
-    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid #1e293b">Skip to main content</a>
+    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid var(--aucto-border-dark)">Skip to main content</a>
 
     <!-- Header (rendered by JavaScript) -->
     <div id="header"></div>
@@ -101,7 +101,7 @@
     >
       <div
         class="bg-white p-8 max-w-md w-full"
-        style="border: 3px solid #1e293b"
+        style="border: 3px solid var(--aucto-border-dark)"
       >
         <div class="flex items-center gap-3 mb-6">
           <i class="fa-solid fa-triangle-exclamation text-3xl text-red-600"></i>

--- a/listing.html
+++ b/listing.html
@@ -82,7 +82,7 @@
   </head>
   <body class="antialiased bg-aucto-bg" data-page-type="browse">
     <!-- Skip Navigation Link -->
-    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid #1e293b">Skip to main content</a>
+    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid var(--aucto-border-dark)">Skip to main content</a>
 
     <!-- Header (rendered by JavaScript) -->
     <div id="header"></div>
@@ -101,7 +101,7 @@
             <!-- LEFT: MEDIA + DESCRIPTION -->
             <div class="space-y-6 flex flex-col">
               <!-- Lot Header -->
-              <div class="bg-white p-6 md:p-8 flex-shrink-0" style="border: 3px solid #1e293b">
+              <div class="bg-white p-6 md:p-8 flex-shrink-0" style="border: 3px solid var(--aucto-border-dark)">
                 <div id="listing-header">
                   <!-- Loading state -->
                   <div class="animate-pulse space-y-4">
@@ -113,7 +113,7 @@
               </div>
 
               <!-- Media Gallery -->
-              <div class="bg-white p-4 md:p-6 flex-grow" style="border: 3px solid #1e293b">
+              <div class="bg-white p-4 md:p-6 flex-grow" style="border: 3px solid var(--aucto-border-dark)">
                 <div id="media-gallery">
                   <!-- Loading state -->
                   <div class="animate-pulse">
@@ -132,7 +132,7 @@
             <!-- RIGHT: BID PANEL -->
             <aside class="space-y-6 flex flex-col h-full">
               <!-- Bid input -->
-              <div class="bg-white p-6 flex-shrink-0" style="border: 3px solid #1e293b">
+              <div class="bg-white p-6 flex-shrink-0" style="border: 3px solid var(--aucto-border-dark)">
                 <div id="bid-panel">
                   <!-- Loading state -->
                   <div class="animate-pulse space-y-6">
@@ -149,7 +149,7 @@
                 <button
                   id="watch-btn"
                   class="flex-1 bg-white px-4 py-3 text-xs font-bold tracking-[0.18em] uppercase text-slate-700 hover:bg-slate-50 transition-colors inline-flex items-center justify-center gap-2"
-                  style="border: 3px solid #334155"
+                  style="border: 3px solid var(--aucto-border-mid)"
                   aria-label="Add to watchlist"
                 >
                   <i class="fa-solid fa-bookmark text-sm"></i>
@@ -158,7 +158,7 @@
                 <button
                   id="share-btn"
                   class="flex-1 bg-white px-4 py-3 text-xs font-bold tracking-[0.18em] uppercase text-slate-700 hover:bg-slate-50 transition-colors inline-flex items-center justify-center gap-2"
-                  style="border: 3px solid #334155"
+                  style="border: 3px solid var(--aucto-border-mid)"
                   aria-label="Share listing"
                 >
                   <i class="fa-solid fa-share text-sm"></i>
@@ -167,7 +167,7 @@
               </div>
 
               <!-- Tags -->
-              <div class="bg-white p-6 flex-shrink-0" style="border: 3px solid #1e293b" id="tags-section">
+              <div class="bg-white p-6 flex-shrink-0" style="border: 3px solid var(--aucto-border-dark)" id="tags-section">
                 <!-- Loading state -->
                 <div class="animate-pulse space-y-3">
                   <div class="h-4 bg-slate-200 rounded w-1/4"></div>
@@ -180,7 +180,7 @@
               </div>
 
               <!-- Details block -->
-              <div class="bg-white p-6 flex-grow" style="border: 3px solid #1e293b">
+              <div class="bg-white p-6 flex-grow" style="border: 3px solid var(--aucto-border-dark)">
                 <div id="listing-details">
                   <!-- Loading state -->
                   <div class="animate-pulse space-y-4">
@@ -195,7 +195,7 @@
           <!-- Bottom: Bids, Seller, Meta -->
           <div class="mt-12 grid gap-8 lg:grid-cols-3">
             <!-- Bid history -->
-            <div class="bg-white p-8" style="border: 3px solid #1e293b">
+            <div class="bg-white p-8" style="border: 3px solid var(--aucto-border-dark)">
               <h2 class="mb-6 text-2xl font-bold text-slate-900">Bid History</h2>
               <div id="bid-history">
                 <!-- Loading state -->
@@ -208,7 +208,7 @@
             </div>
 
             <!-- Seller info -->
-            <div class="bg-white p-8" style="border: 3px solid #1e293b">
+            <div class="bg-white p-8" style="border: 3px solid var(--aucto-border-dark)">
               <h2 class="mb-6 text-2xl font-bold text-slate-900">Seller Profile</h2>
               <div id="seller-profile">
                 <!-- Loading state -->
@@ -226,7 +226,7 @@
             </div>
 
             <!-- Listing meta -->
-            <div class="bg-white p-8" style="border: 3px solid #1e293b">
+            <div class="bg-white p-8" style="border: 3px solid var(--aucto-border-dark)">
               <h2 class="mb-6 text-2xl font-bold text-slate-900">Listing Details</h2>
               <div id="listing-meta">
                 <!-- Loading state -->

--- a/login.html
+++ b/login.html
@@ -59,7 +59,7 @@
   </head>
   <body class="antialiased bg-aucto-bg" data-page-type="auth">
     <!-- Skip Navigation Link -->
-    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid #1e293b">Skip to main content</a>
+    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid var(--aucto-border-dark)">Skip to main content</a>
 
     <!-- Header (rendered by JavaScript) -->
     <div id="header"></div>
@@ -69,20 +69,20 @@
       <section class="px-6 py-10 mx-auto max-w-7xl md:px-8 md:py-14">
         <div
           class="p-6 bg-white md:p-8 lg:p-10"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
         >
           <div class="grid gap-6 lg:grid-cols-[3fr,2fr] lg:gap-8 items-stretch">
             <!-- LEFT: LOGIN TILE -->
             <section
               aria-label="Login to Aucto"
               class="flex flex-col justify-between p-6 bg-slate-50 md:p-8"
-              style="border: 3px solid #1e293b"
+              style="border: 3px solid var(--aucto-border-dark)"
             >
               <!-- Label + status -->
               <div class="mb-6">
                 <div class="flex items-center justify-between gap-4 mb-4">
                   <div class="flex items-center gap-3">
-                    <div class="h-0.5 w-12 bg-red-700"></div>
+                    <div class="h-0.5 w-12 bg-aucto-red"></div>
                     <span
                       class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500"
                     >
@@ -135,8 +135,8 @@
                     type="email"
                     autocomplete="email"
                     placeholder="your.name@stud.noroff.no"
-                    class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                    style="border: 3px solid #334155"
+                    class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                    style="border: 3px solid var(--aucto-border-mid)"
                     required
                   />
                   <div id="email-error" class="hidden mt-2 text-xs text-red-700"></div>
@@ -156,8 +156,8 @@
                     type="password"
                     autocomplete="current-password"
                     placeholder="Enter your password"
-                    class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                    style="border: 3px solid #334155"
+                    class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                    style="border: 3px solid var(--aucto-border-mid)"
                     required
                   />
                   <div id="password-error" class="hidden mt-2 text-xs text-red-700"></div>
@@ -173,7 +173,7 @@
                   <button
                     type="submit"
                     class="w-full bg-slate-900 py-3 text-sm font-bold tracking-[0.18em] uppercase text-white hover:bg-slate-800 inline-flex items-center justify-center gap-2"
-                    style="border: 3px solid #1e293b"
+                    style="border: 3px solid var(--aucto-border-dark)"
                   >
                     <i class="fa-solid fa-right-to-bracket"></i>
                     <span>Log in to bid</span>
@@ -181,7 +181,7 @@
                   <a
                     href="/register.html"
                     class="w-full bg-white py-3 text-[11px] text-center font-bold tracking-[0.18em] uppercase text-slate-900 hover:bg-slate-50 inline-flex items-center justify-center gap-2"
-                    style="border: 3px solid #334155"
+                    style="border: 3px solid var(--aucto-border-mid)"
                   >
                     <i class="text-xs fa-solid fa-user-plus"></i>
                     Create account
@@ -225,12 +225,12 @@
               <article
                 data-tile="featured"
                 class="bg-slate-50"
-                style="border: 3px solid #1e293b"
+                style="border: 3px solid var(--aucto-border-dark)"
                 aria-label="Example auction lot"
               >
                 <div
                   class="relative h-40 sm:h-48 md:h-56 bg-slate-200"
-                  style="border-bottom: 3px solid #1e293b"
+                  style="border-bottom: 3px solid var(--aucto-border-dark)"
                 >
                   <img
                     src="https://images.unsplash.com/photo-1505740420928-5e560c06d30e?w=900&h=600&fit=crop"
@@ -244,7 +244,7 @@
                   </div>
                   <div
                     class="absolute px-3 py-1 text-xs font-semibold bg-white right-3 bottom-3 text-slate-900"
-                    style="border: 3px solid #1e293b"
+                    style="border: 3px solid var(--aucto-border-dark)"
                   >
                     Current bid: <span id="featured-bid">520</span> credits
                   </div>
@@ -270,11 +270,11 @@
                 <article
                   data-tile="tile-a"
                   class="flex flex-col bg-slate-50"
-                  style="border: 3px solid #1e293b"
+                  style="border: 3px solid var(--aucto-border-dark)"
                 >
                   <div
                     class="h-48 sm:h-52 md:h-56 bg-slate-200"
-                    style="border-bottom: 3px solid #1e293b"
+                    style="border-bottom: 3px solid var(--aucto-border-dark)"
                   >
                     <img
                       src="https://images.unsplash.com/photo-1546868871-7041f2a55e12?w=600&h=400&fit=crop"
@@ -301,11 +301,11 @@
                 <article
                   data-tile="tile-b"
                   class="flex flex-col bg-slate-50"
-                  style="border: 3px solid #1e293b"
+                  style="border: 3px solid var(--aucto-border-dark)"
                 >
                   <div
                     class="h-48 sm:h-52 md:h-56 bg-slate-200"
-                    style="border-bottom: 3px solid #1e293b"
+                    style="border-bottom: 3px solid var(--aucto-border-dark)"
                   >
                     <img
                       src="https://images.unsplash.com/photo-1511379938547-c1f69419868d?w=600&h=400&fit=crop"

--- a/profile.html
+++ b/profile.html
@@ -59,7 +59,7 @@
   </head>
   <body class="antialiased bg-aucto-bg" data-page-type="user-content">
     <!-- Skip Navigation Link -->
-    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid #1e293b">Skip to main content</a>
+    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid var(--aucto-border-dark)">Skip to main content</a>
 
     <!-- Header (rendered by JavaScript) -->
     <div id="header"></div>

--- a/register.html
+++ b/register.html
@@ -67,7 +67,7 @@
   </head>
   <body class="antialiased bg-aucto-bg" data-page-type="auth">
     <!-- Skip Navigation Link -->
-    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid #1e293b">Skip to main content</a>
+    <a href="#main-content" class="absolute -top-10 left-0 z-[100] bg-slate-900 text-white px-4 py-2 text-sm font-bold no-underline focus:top-0 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2" style="border: 3px solid var(--aucto-border-dark)">Skip to main content</a>
 
     <!-- Header (rendered by JavaScript) -->
     <div id="header"></div>
@@ -77,20 +77,20 @@
       <section class="px-4 py-10 mx-auto max-w-7xl md:px-8 md:py-14">
         <div
           class="p-4 bg-white md:p-8 lg:p-10"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
         >
           <div class="grid gap-6 lg:grid-cols-[3fr,2fr] lg:gap-8 items-stretch">
             <!-- LEFT: REGISTER TILE -->
             <section
               aria-label="Create Aucto account"
               class="flex flex-col justify-between p-4 bg-slate-50 md:p-8"
-              style="border: 3px solid #1e293b"
+              style="border: 3px solid var(--aucto-border-dark)"
             >
               <!-- Label + status -->
               <div class="mb-6">
                 <div class="flex items-center justify-between gap-4 mb-4">
                   <div class="flex items-center gap-3">
-                    <div class="h-0.5 w-12 bg-red-700"></div>
+                    <div class="h-0.5 w-12 bg-aucto-red"></div>
                     <span
                       class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500"
                     >
@@ -144,8 +144,8 @@
                     type="text"
                     autocomplete="name"
                     placeholder="First name and last name"
-                    class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                    style="border: 3px solid #334155"
+                    class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                    style="border: 3px solid var(--aucto-border-mid)"
                     required
                   />
                   <div id="name-error" class="hidden mt-2 text-xs text-red-700"></div>
@@ -165,8 +165,8 @@
                     type="email"
                     autocomplete="email"
                     placeholder="your.name@stud.noroff.no"
-                    class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                    style="border: 3px solid #334155"
+                    class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                    style="border: 3px solid var(--aucto-border-mid)"
                     required
                   />
                   <p class="mt-2 text-xs text-slate-500">
@@ -190,8 +190,8 @@
                       type="password"
                       autocomplete="new-password"
                       placeholder="Create a password"
-                      class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                      style="border: 3px solid #334155"
+                      class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                      style="border: 3px solid var(--aucto-border-mid)"
                       required
                     />
                     <p class="mt-1 text-xs text-slate-500">
@@ -213,8 +213,8 @@
                       type="password"
                       autocomplete="new-password"
                       placeholder="Repeat your password"
-                      class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                      style="border: 3px solid #334155"
+                      class="w-full px-4 py-3 text-sm bg-white text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                      style="border: 3px solid var(--aucto-border-mid)"
                       required
                     />
                     <div id="confirm-password-error" class="hidden mt-2 text-xs text-red-700"></div>
@@ -225,7 +225,7 @@
                   <button
                     type="submit"
                     class="w-full bg-slate-900 py-3 text-sm font-bold tracking-[0.18em] uppercase text-white hover:bg-slate-800 inline-flex items-center justify-center gap-2"
-                    style="border: 3px solid #1e293b"
+                    style="border: 3px solid var(--aucto-border-dark)"
                   >
                     <i class="fa-solid fa-user-plus"></i>
                     <span>Create account</span>
@@ -233,7 +233,7 @@
                   <a
                     href="/login.html"
                     class="w-full bg-white py-3 text-[11px] text-center font-bold tracking-[0.18em] uppercase text-slate-900 hover:bg-slate-50 inline-flex items-center justify-center gap-2"
-                    style="border: 3px solid #334155"
+                    style="border: 3px solid var(--aucto-border-mid)"
                   >
                     <i class="text-xs fa-solid fa-sign-in-alt"></i>
                     Already registered? Log in
@@ -277,12 +277,12 @@
               <article
                 data-tile="featured"
                 class="bg-slate-50"
-                style="border: 3px solid #1e293b"
+                style="border: 3px solid var(--aucto-border-dark)"
                 aria-label="Example listing creation"
               >
                 <div
                   class="relative h-40 sm:h-48 md:h-56 bg-slate-200"
-                  style="border-bottom: 3px solid #1e293b"
+                  style="border-bottom: 3px solid var(--aucto-border-dark)"
                 >
                   <img
                     src="https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?w=900&h=600&fit=crop"
@@ -296,7 +296,7 @@
                   </div>
                   <div
                     class="absolute px-3 py-1 text-xs font-semibold bg-white right-3 bottom-3 text-slate-900"
-                    style="border: 3px solid #1e293b"
+                    style="border: 3px solid var(--aucto-border-dark)"
                   >
                     <span id="starter-credits">1000</span> starter credits
                   </div>
@@ -322,11 +322,11 @@
                 <article
                   data-tile="tile-a"
                   class="flex flex-col bg-slate-50"
-                  style="border: 3px solid #1e293b"
+                  style="border: 3px solid var(--aucto-border-dark)"
                 >
                   <div
                     class="h-48 sm:h-52 md:h-56 bg-slate-200"
-                    style="border-bottom: 3px solid #1e293b"
+                    style="border-bottom: 3px solid var(--aucto-border-dark)"
                   >
                     <img
                       src="https://images.unsplash.com/photo-1523275335684-37898b6baf30?w=600&h=400&fit=crop"
@@ -353,11 +353,11 @@
                 <article
                   data-tile="tile-b"
                   class="flex flex-col bg-slate-50"
-                  style="border: 3px solid #1e293b"
+                  style="border: 3px solid var(--aucto-border-dark)"
                 >
                   <div
                     class="h-48 sm:h-52 md:h-56 bg-slate-200"
-                    style="border-bottom: 3px solid #1e293b"
+                    style="border-bottom: 3px solid var(--aucto-border-dark)"
                   >
                     <img
                       src="https://images.unsplash.com/photo-1556656793-08538906a9f8?w=600&h=400&fit=crop"

--- a/src/components/Bidistory.ts
+++ b/src/components/Bidistory.ts
@@ -119,7 +119,7 @@ export function createBidForm(
             step="1"
             required
             placeholder="${minimumBid}"
-            class="w-full px-4 py-3 text-lg font-bold border-2 border-slate-900 focus:outline-none focus:border-blue-500"
+            class="w-full px-4 py-3 text-lg font-bold border-2 border-slate-900 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
           />
           <span class="absolute right-4 top-1/2 -translate-y-1/2 text-slate-500">
             credits

--- a/src/components/CollectionCard.ts
+++ b/src/components/CollectionCard.ts
@@ -67,7 +67,7 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
 
     if (bids.length === 0) {
       return `
-        <div class="absolute top-3 left-3 bg-blue-600 px-3 py-1 text-xs font-bold text-white" style="border: 2px solid #1e40af">
+        <div class="absolute top-3 left-3 bg-slate-900 px-3 py-1 text-xs font-bold text-white" style="border: 2px solid var(--aucto-border-dark)">
           NEW
         </div>`;
     }
@@ -94,7 +94,7 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
     return `
       <article
         class="bg-white transition-all duration-300 hover:shadow-xl group relative flex flex-col sm:flex-row"
-        style="border: 3px solid #1e293b"
+        style="border: 3px solid var(--aucto-border-dark)"
         data-listing-id="${listing.id}"
       >
         <!-- Image Section (Fixed width in list view) -->
@@ -129,13 +129,13 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
             <!-- Lot Number + Category Badge -->
             <div class="mb-3 flex items-center gap-3 text-[11px] font-bold tracking-[0.18em] uppercase">
               <span class="text-slate-500">Lot ${listing.id.slice(-3)}</span>
-              <span class="bg-blue-100 text-blue-800 px-2 py-1" style="border: 1px solid #3b82f6">
+              <span class="bg-slate-100 text-slate-800 px-2 py-1" style="border: 1px solid var(--aucto-border-mid)">
                 ${tag}
               </span>
             </div>
 
             <!-- Title -->
-            <h3 class="mb-3 text-2xl font-bold leading-tight text-slate-900 group-hover:text-blue-600 transition-colors">
+            <h3 class="mb-3 text-2xl font-bold leading-tight text-slate-900 group-hover:text-aucto-red transition-colors">
               <a href="/listing.html?id=${listing.id}" class="hover:underline">
                 ${listing.title}
               </a>
@@ -172,8 +172,8 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
 
             <!-- CTA Button -->
             <button
-              class="bg-slate-900 px-8 py-3 text-xs font-bold tracking-wide text-white hover:bg-blue-600 transition-all inline-flex items-center justify-center gap-2"
-              style="border: 3px solid #1e293b"
+              class="bg-slate-900 px-8 py-3 text-xs font-bold tracking-wide text-white hover:bg-slate-800 transition-all inline-flex items-center justify-center gap-2"
+              style="border: 3px solid var(--aucto-border-dark)"
               data-action="view-bid"
               data-listing-id="${listing.id}"
               ${!isActive ? 'disabled' : ''}
@@ -191,12 +191,12 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
   return `
     <article
       class="bg-white transition-all duration-300 hover:-translate-y-2 hover:shadow-2xl group relative"
-      style="border: 3px solid #1e293b"
+      style="border: 3px solid var(--aucto-border-dark)"
       data-listing-id="${listing.id}"
     >
       <div class="relative overflow-hidden">
         <!-- Image -->
-        <div class="aspect-square bg-slate-100 overflow-hidden" style="border-bottom: 3px solid #1e293b">
+        <div class="aspect-square bg-slate-100 overflow-hidden" style="border-bottom: 3px solid var(--aucto-border-dark)">
           <a href="/listing.html?id=${listing.id}" class="block h-full">
             <img
               src="${imgAttrs.src}"
@@ -216,7 +216,7 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
           <div class="absolute inset-0 bg-slate-900 bg-opacity-0 group-hover:bg-opacity-40 transition-all duration-300 flex items-center justify-center">
             <button
               class="bg-white px-6 py-3 text-xs font-bold text-slate-900 opacity-0 group-hover:opacity-100 transform translate-y-4 group-hover:translate-y-0 transition-all duration-300"
-              style="border: 3px solid #1e293b"
+              style="border: 3px solid var(--aucto-border-dark)"
               data-action="quick-view"
               data-listing-id="${listing.id}"
             >
@@ -237,13 +237,13 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
         <!-- Lot Number + Category Badge -->
         <div class="mb-3 flex items-center justify-between text-[11px] font-bold tracking-[0.18em] uppercase">
           <span class="text-slate-500">Lot ${listing.id.slice(-3)}</span>
-          <span class="bg-blue-100 text-blue-800 px-2 py-1" style="border: 1px solid #3b82f6">
+          <span class="bg-slate-100 text-slate-800 px-2 py-1" style="border: 1px solid var(--aucto-border-mid)">
             ${tag}
           </span>
         </div>
 
         <!-- Title -->
-        <h3 class="mb-3 text-xl font-bold leading-tight text-slate-900 group-hover:text-blue-600 transition-colors">
+        <h3 class="mb-3 text-xl font-bold leading-tight text-slate-900 group-hover:text-aucto-red transition-colors">
           <a href="/listing.html?id=${listing.id}" class="hover:underline">
             ${listing.title}
           </a>
@@ -270,8 +270,8 @@ export function createCollectionCard(listing: Listing, viewMode: 'grid' | 'list'
 
         <!-- CTA Button -->
         <button
-          class="w-full bg-slate-900 py-3 text-xs font-bold tracking-wide text-white hover:bg-blue-600 transition-all transform hover:scale-105 inline-flex items-center justify-center gap-2"
-          style="border: 3px solid #1e293b"
+          class="w-full bg-slate-900 py-3 text-xs font-bold tracking-wide text-white hover:bg-slate-800 transition-all transform hover:scale-105 inline-flex items-center justify-center gap-2"
+          style="border: 3px solid var(--aucto-border-dark)"
           data-action="view-bid"
           data-listing-id="${listing.id}"
           ${!isActive ? 'disabled' : ''}
@@ -297,7 +297,7 @@ export function renderCollectionCards(
 
   if (listings.length === 0) {
     container.innerHTML = `
-      <div class="col-span-full bg-white p-12 text-center" style="border: 3px solid #1e293b">
+      <div class="col-span-full bg-white p-12 text-center" style="border: 3px solid var(--aucto-border-dark)">
         <div class="max-w-md mx-auto">
           <svg class="w-24 h-24 mx-auto mb-6 text-slate-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -399,8 +399,8 @@ export function attachCollectionCardEvents(containerId: string = 'collection-car
 
 export function createCollectionCardSkeleton(): string {
   return `
-    <div class="bg-white animate-pulse" style="border: 2px solid #1e293b">
-      <div class="aspect-square bg-slate-200" style="border-bottom: 2px solid #1e293b"></div>
+    <div class="bg-white animate-pulse" style="border: 3px solid var(--aucto-border-dark)">
+      <div class="aspect-square bg-slate-200" style="border-bottom: 3px solid var(--aucto-border-dark)"></div>
       <div class="p-5">
         <div class="mb-3 flex items-center justify-between">
           <div class="h-3 bg-slate-200 rounded w-16"></div>

--- a/src/components/FeaturedWin.ts
+++ b/src/components/FeaturedWin.ts
@@ -54,13 +54,13 @@ export function renderFeaturedWin(data: FeaturedWinData): string {
   } else {
     labelText = 'Popular Auction';
     statusText = 'Active';
-    statusColor = 'text-blue-400';
+    statusColor = 'text-slate-300';
   }
 
   return `
-    <div class="mb-20 bg-slate-800 p-10 lg:p-12" style="border: 3px solid #334155">
+    <div class="mb-20 bg-slate-800 p-10 lg:p-12" style="border: 3px solid var(--aucto-border-mid)">
       <div class="mb-6 flex items-center gap-4">
-        <div class="h-0.5 w-12 ${data.isUserWin ? 'bg-green-500' : data.isEnded ? 'bg-red-700' : 'bg-blue-500'}"></div>
+        <div class="h-0.5 w-12 ${data.isUserWin ? 'bg-green-500' : data.isEnded ? 'bg-aucto-red' : 'bg-slate-500'}"></div>
         <span class="text-xs font-bold tracking-widest text-slate-400 uppercase">
           ${labelText}
         </span>
@@ -228,7 +228,7 @@ export async function initFeaturedWin(): Promise<void> {
 
   // Loading state
   container.innerHTML = `
-    <div class="mb-20 bg-slate-800 p-10 lg:p-12 flex items-center justify-center" style="border: 3px solid #334155">
+    <div class="mb-20 bg-slate-800 p-10 lg:p-12 flex items-center justify-center" style="border: 3px solid var(--aucto-border-mid)">
       <div class="text-slate-400">
         <i class="fa-solid fa-spinner fa-spin text-2xl"></i>
       </div>

--- a/src/components/Footer.ts
+++ b/src/components/Footer.ts
@@ -248,7 +248,7 @@ export function renderFooter(): void {
     <!-- Bottom Bar -->
     <div
       class="flex flex-col items-center justify-between gap-8 pt-12 md:flex-row"
-      style="border-top: 2px solid #334155"
+      style="border-top: 2px solid var(--aucto-border-mid)"
     >
       <div class="text-sm text-slate-500">
         &copy; 2025 Aucto. All rights reserved.

--- a/src/components/Navbar.ts
+++ b/src/components/Navbar.ts
@@ -90,7 +90,7 @@ function renderMinimalNavbar(): string {
   return `
     <nav aria-label="Main navigation" style="background-color: #f7f7f5">
       <div class="mx-auto max-w-7xl px-6 md:px-8 pt-5">
-        <div class="flex items-center justify-between gap-6 pb-4" style="border-bottom: 1px solid #e2e8f0">
+        <div class="flex items-center justify-between gap-6 pb-4" style="border-bottom: 1px solid var(--aucto-border-light)">
           <!-- Brand Logo -->
           <a href="/index.html" class="inline-flex items-center text-slate-900 hover:text-slate-700 transition-colors whitespace-nowrap flex-shrink-0" aria-label="Aucto home">
             <img src="/images/logo_v2.svg" alt="Aucto logo" class="h-9" width="120" height="36" />
@@ -117,7 +117,7 @@ function renderSimpleNavbar(isUserLoggedIn: boolean, user: User | null): string 
   return `
     <nav aria-label="Main navigation" style="background-color: #f7f7f5">
       <div class="mx-auto max-w-7xl px-6 md:px-8 pt-5">
-        <div class="flex items-center justify-between gap-6 pb-4" style="border-bottom: 1px solid #e2e8f0">
+        <div class="flex items-center justify-between gap-6 pb-4" style="border-bottom: 1px solid var(--aucto-border-light)">
 
           <!-- Brand Logo -->
           <a href="/index.html" class="inline-flex items-center text-slate-900 hover:text-slate-700 transition-colors whitespace-nowrap flex-shrink-0" aria-label="Aucto home">
@@ -174,7 +174,7 @@ function renderFullNavbar(isUserLoggedIn: boolean, user: User | null): string {
     <nav aria-label="Main navigation" style="background-color: #f7f7f5">
       <div class="mx-auto max-w-7xl px-6 md:px-8 pt-5">
         <!-- Top row: brand + search + nav + credits -->
-        <div class="flex items-center gap-3 pb-4" style="border-bottom: 1px solid #e2e8f0">
+        <div class="flex items-center gap-3 pb-4" style="border-bottom: 1px solid var(--aucto-border-light)">
 
           <!-- Brand Logo - Always visible -->
           <a href="/index.html" class="inline-flex items-center text-slate-900 hover:text-slate-700 transition-colors whitespace-nowrap flex-shrink-0" aria-label="Aucto home">
@@ -191,8 +191,8 @@ function renderFullNavbar(isUserLoggedIn: boolean, user: User | null): string {
                   name="q"
                   type="search"
                   placeholder="Search by title, description, or lot number..."
-                  class="w-full bg-slate-50 px-4 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                  style="border: 2px solid #334155"
+                  class="w-full bg-slate-50 px-4 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                  style="border: 2px solid var(--aucto-border-mid)"
                 />
                 <i class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 fa-solid fa-magnifying-glass text-sm text-slate-400" aria-hidden="true"></i>
               </div>
@@ -203,7 +203,7 @@ function renderFullNavbar(isUserLoggedIn: boolean, user: User | null): string {
               id="toggle-advanced-filters"
               type="button"
               class="flex items-center gap-2 bg-white px-3 py-2 hover:bg-slate-50"
-              style="border: 2px solid #334155"
+              style="border: 2px solid var(--aucto-border-mid)"
               aria-expanded="false"
               aria-controls="advanced-filters-bar"
               aria-label="Toggle advanced filters"
@@ -221,7 +221,7 @@ function renderFullNavbar(isUserLoggedIn: boolean, user: User | null): string {
             id="mobile-search-btn"
             type="button"
             class="lg:hidden flex items-center justify-center bg-white px-3 py-2 hover:bg-slate-50"
-            style="border: 2px solid #334155"
+            style="border: 2px solid var(--aucto-border-mid)"
             aria-label="Toggle search"
             aria-expanded="false"
           >
@@ -270,7 +270,7 @@ function renderFullNavbar(isUserLoggedIn: boolean, user: User | null): string {
         <div
           id="mobile-search-bar"
           class="hidden lg:hidden px-2 py-4"
-          style="border-bottom: 1px solid #e2e8f0"
+          style="border-bottom: 1px solid var(--aucto-border-light)"
         >
           <form role="search" aria-label="Search auctions" id="mobile-search-form">
             <label for="mobile-search-input" class="sr-only">Search auctions</label>
@@ -280,8 +280,8 @@ function renderFullNavbar(isUserLoggedIn: boolean, user: User | null): string {
                 name="q"
                 type="search"
                 placeholder="Search auctions..."
-                class="w-full bg-slate-50 px-4 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                style="border: 2px solid #334155"
+                class="w-full bg-slate-50 px-4 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                style="border: 2px solid var(--aucto-border-mid)"
               />
               <i class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 fa-solid fa-magnifying-glass text-sm text-slate-400" aria-hidden="true"></i>
             </div>
@@ -292,7 +292,7 @@ function renderFullNavbar(isUserLoggedIn: boolean, user: User | null): string {
             id="mobile-toggle-filters"
             type="button"
             class="mt-3 w-full flex items-center justify-center gap-2 bg-white px-4 py-2 hover:bg-slate-50"
-            style="border: 2px solid #334155"
+            style="border: 2px solid var(--aucto-border-mid)"
             aria-expanded="false"
             aria-controls="advanced-filters-bar"
             aria-label="Toggle filters"
@@ -336,7 +336,7 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
           ? `
         <!-- Logged In User -->
         <!-- Credits Box -->
-        <div class="hidden items-center gap-2 bg-slate-50 px-4 py-2 sm:flex" style="border: 3px solid #1e293b" aria-label="User credits">
+        <div class="hidden items-center gap-2 bg-slate-50 px-4 py-2 sm:flex" style="border: 3px solid var(--aucto-border-dark)" aria-label="User credits">
           <span class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500">Credits</span>
           <span class="text-base font-bold text-slate-900" aria-label="${new Intl.NumberFormat('en-US').format(user.credits || 0)} credits">${new Intl.NumberFormat('en-US').format(user.credits || 0)}</span>
         </div>
@@ -346,15 +346,15 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
           <button
             id="profile-menu-btn"
             class="flex items-center gap-2 bg-white px-4 py-2 hover:bg-slate-50 transition-colors"
-            style="border: 3px solid #1e293b"
+            style="border: 3px solid var(--aucto-border-dark)"
             aria-expanded="false"
             aria-haspopup="true"
             aria-label="Open profile menu"
           >
             ${
               user.avatar?.url
-                ? `<img src="${user.avatar.url}" alt="${user.name} avatar" class="h-8 w-8 object-cover" width="32" height="32" loading="lazy" referrerpolicy="no-referrer" style="border: 2px solid #1e293b" />`
-                : `<div class="h-8 w-8 bg-slate-900 text-white flex items-center justify-center font-bold text-sm" style="border: 2px solid #1e293b" aria-hidden="true">${user.name.charAt(0).toUpperCase()}</div>`
+                ? `<img src="${user.avatar.url}" alt="${user.name} avatar" class="h-8 w-8 object-cover" width="32" height="32" loading="lazy" referrerpolicy="no-referrer" style="border: 2px solid var(--aucto-border-dark)" />`
+                : `<div class="h-8 w-8 bg-slate-900 text-white flex items-center justify-center font-bold text-sm" style="border: 2px solid var(--aucto-border-dark)" aria-hidden="true">${user.name.charAt(0).toUpperCase()}</div>`
             }
             <span class="text-sm font-bold text-slate-900">${user.name}</span>
             <i class="fa-solid fa-chevron-down text-xs text-slate-500 transition-transform" id="profile-menu-chevron" aria-hidden="true"></i>
@@ -364,7 +364,7 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
           <div
             id="profile-dropdown-menu"
             class="hidden absolute right-0 mt-2 w-56 bg-white shadow-2xl z-50 transform origin-top-right transition-all"
-            style="border: 3px solid #1e293b"
+            style="border: 3px solid var(--aucto-border-dark)"
             role="menu"
             aria-label="Profile menu"
           >
@@ -374,14 +374,14 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
                 <i class="fa-solid fa-user w-5 text-slate-600" aria-hidden="true"></i>
                 <span>My Profile</span>
               </a>
-              <a href="/listing-create.html" class="flex items-center gap-3 px-4 py-3 text-sm font-bold text-slate-900 hover:bg-slate-50 transition-colors border-t" style="border-color: #e2e8f0" role="menuitem">
+              <a href="/listing-create.html" class="flex items-center gap-3 px-4 py-3 text-sm font-bold text-slate-900 hover:bg-slate-50 transition-colors border-t" style="border-color: var(--aucto-border-light)" role="menuitem">
                 <i class="fa-solid fa-plus w-5 text-slate-600" aria-hidden="true"></i>
                 <span>Create Listing</span>
               </a>
               <button
                 id="logout-btn"
                 class="w-full flex items-center gap-3 px-4 py-3 text-sm font-bold text-red-700 hover:bg-red-50 transition-colors border-t"
-                style="border-color: #e2e8f0"
+                style="border-color: var(--aucto-border-light)"
                 role="menuitem"
               >
                 <i class="fa-solid fa-sign-out-alt w-5" aria-hidden="true"></i>
@@ -396,7 +396,7 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
           id="mobile-menu-btn"
           type="button"
           class="lg:hidden flex items-center justify-center bg-slate-900 px-2.5 py-2 hover:bg-slate-800"
-          style="border: 2px solid #1e293b"
+          style="border: 2px solid var(--aucto-border-dark)"
           aria-expanded="false"
           aria-label="Toggle menu"
         >
@@ -408,7 +408,7 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
         <a
           href="/login.html"
           class="hidden bg-white px-4 py-2 text-sm font-bold tracking-wide text-slate-900 hover:bg-slate-50 md:inline-flex items-center gap-2"
-          style="border: 2px solid #1e293b"
+          style="border: 2px solid var(--aucto-border-dark)"
           aria-label="Log in to your account"
         >
           <i class="fa-solid fa-right-to-bracket text-sm" aria-hidden="true"></i>
@@ -419,7 +419,7 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
         <a
           href="/register.html"
           class="hidden lg:inline-flex items-center gap-2 bg-slate-900 px-5 py-2 text-sm font-bold tracking-wide text-white hover:bg-slate-800"
-          style="border: 2px solid #1e293b"
+          style="border: 2px solid var(--aucto-border-dark)"
           aria-label="Create new account"
         >
           <i class="fa-solid fa-user-plus text-sm" aria-hidden="true"></i>
@@ -430,7 +430,7 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
         <a
           href="/register.html"
           class="hidden sm:inline-flex lg:hidden items-center gap-1.5 bg-slate-900 px-3 py-2 text-xs font-bold tracking-wide text-white hover:bg-slate-800"
-          style="border: 2px solid #1e293b"
+          style="border: 2px solid var(--aucto-border-dark)"
           aria-label="Create new account"
         >
           <i class="fa-solid fa-user-plus text-xs" aria-hidden="true"></i>
@@ -442,7 +442,7 @@ function renderUserSection(isUserLoggedIn: boolean, user: User | null): string {
           id="mobile-menu-btn"
           type="button"
           class="lg:hidden flex items-center justify-center bg-slate-900 px-2.5 py-2 hover:bg-slate-800"
-          style="border: 2px solid #1e293b"
+          style="border: 2px solid var(--aucto-border-dark)"
           aria-expanded="false"
           aria-label="Toggle menu"
         >
@@ -465,7 +465,7 @@ function renderMobileMenu(isUserLoggedIn: boolean, user: User | null): string {
     <aside
       id="mobile-menu-drawer"
       class="fixed top-0 right-0 bottom-0 w-80 bg-white transform translate-x-full transition-transform duration-300 ease-in-out z-50 overflow-y-auto"
-      style="border-left: 3px solid #1e293b"
+      style="border-left: 3px solid var(--aucto-border-dark)"
       role="dialog"
       aria-label="Mobile menu"
       aria-modal="true"
@@ -474,12 +474,12 @@ function renderMobileMenu(isUserLoggedIn: boolean, user: User | null): string {
         isUserLoggedIn && user
           ? `
       <!-- Mobile Menu Header - Logged In -->
-      <div class="flex items-center justify-between p-4" style="border-bottom: 2px solid #e2e8f0">
+      <div class="flex items-center justify-between p-4" style="border-bottom: 2px solid var(--aucto-border-light)">
         <div class="flex items-center gap-2">
           ${
             user.avatar?.url
-              ? `<img src="${user.avatar.url}" alt="${user.name} avatar" class="h-10 w-10 object-cover" width="40" height="40" loading="lazy" referrerpolicy="no-referrer" style="border: 2px solid #1e293b" />`
-              : `<div class="h-10 w-10 bg-slate-900 text-white flex items-center justify-center font-bold" style="border: 2px solid #1e293b" aria-hidden="true">${user.name.charAt(0).toUpperCase()}</div>`
+              ? `<img src="${user.avatar.url}" alt="${user.name} avatar" class="h-10 w-10 object-cover" width="40" height="40" loading="lazy" referrerpolicy="no-referrer" style="border: 2px solid var(--aucto-border-dark)" />`
+              : `<div class="h-10 w-10 bg-slate-900 text-white flex items-center justify-center font-bold" style="border: 2px solid var(--aucto-border-dark)" aria-hidden="true">${user.name.charAt(0).toUpperCase()}</div>`
           }
           <div>
             <div class="text-sm font-bold text-slate-900">${user.name}</div>
@@ -518,7 +518,7 @@ function renderMobileMenu(isUserLoggedIn: boolean, user: User | null): string {
         </div>
 
         <!-- Divider -->
-        <div class="my-4" style="border-top: 2px solid #e2e8f0"></div>
+        <div class="my-4" style="border-top: 2px solid var(--aucto-border-light)"></div>
 
         <!-- Logout -->
         <button id="mobile-logout-btn" class="w-full flex items-center gap-3 px-4 py-3 text-sm font-bold text-red-600 hover:bg-red-50 rounded transition-colors" aria-label="Logout">
@@ -529,7 +529,7 @@ function renderMobileMenu(isUserLoggedIn: boolean, user: User | null): string {
       `
           : `
       <!-- Mobile Menu Header - Guest -->
-      <div class="flex items-center justify-between p-4" style="border-bottom: 2px solid #e2e8f0">
+      <div class="flex items-center justify-between p-4" style="border-bottom: 2px solid var(--aucto-border-light)">
         <div class="flex items-center gap-2">
           <img src="/images/logo_v2.svg" alt="Aucto logo" class="h-8" width="107" height="32" />
         </div>
@@ -565,15 +565,15 @@ function renderMobileMenu(isUserLoggedIn: boolean, user: User | null): string {
         </div>
 
         <!-- Divider -->
-        <div class="my-4" style="border-top: 2px solid #e2e8f0"></div>
+        <div class="my-4" style="border-top: 2px solid var(--aucto-border-light)"></div>
 
         <!-- Auth Buttons -->
         <div class="space-y-2">
-          <a href="/login.html" class="w-full flex items-center justify-center gap-2 bg-white px-4 py-3 text-sm font-bold tracking-wide text-slate-900 hover:bg-slate-50" style="border: 2px solid #1e293b" aria-label="Log in to your account">
+          <a href="/login.html" class="w-full flex items-center justify-center gap-2 bg-white px-4 py-3 text-sm font-bold tracking-wide text-slate-900 hover:bg-slate-50" style="border: 2px solid var(--aucto-border-dark)" aria-label="Log in to your account">
             <i class="fa-solid fa-right-to-bracket text-sm" aria-hidden="true"></i>
             <span>Log in</span>
           </a>
-          <a href="/register.html" class="w-full flex items-center justify-center gap-2 bg-slate-900 px-4 py-3 text-sm font-bold tracking-wide text-white hover:bg-slate-800" style="border: 2px solid #1e293b" aria-label="Create new account">
+          <a href="/register.html" class="w-full flex items-center justify-center gap-2 bg-slate-900 px-4 py-3 text-sm font-bold tracking-wide text-white hover:bg-slate-800" style="border: 2px solid var(--aucto-border-dark)" aria-label="Create new account">
             <i class="fa-solid fa-user-plus text-sm" aria-hidden="true"></i>
             <span>Create account</span>
           </a>

--- a/src/components/Newsletter.ts
+++ b/src/components/Newsletter.ts
@@ -2,9 +2,9 @@ import { isValidEmail } from '../utils/validation';
 
 export function renderNewsletter(): string {
   return `
-    <div class="mb-20 bg-slate-800 p-10 lg:p-12" style="border: 3px solid #334155">
+    <div class="mb-20 bg-slate-800 p-10 lg:p-12" style="border: 3px solid var(--aucto-border-mid)">
       <div class="mb-6 flex items-center gap-4">
-        <div class="h-0.5 w-12 bg-red-700"></div>
+        <div class="h-0.5 w-12 bg-aucto-red"></div>
         <span class="text-xs font-bold tracking-widest text-slate-400 uppercase">
           Never Miss
         </span>
@@ -24,8 +24,8 @@ export function renderNewsletter(): string {
             name="email"
             placeholder="your.email@stud.noroff.no"
             required
-            class="w-full bg-slate-50 px-6 py-4 text-sm font-normal text-slate-900 transition-colors placeholder:text-slate-400 focus:outline-none"
-            style="border: 2px solid #334155"
+            class="w-full bg-slate-50 px-6 py-4 text-sm font-normal text-slate-900 transition-colors placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+            style="border: 2px solid var(--aucto-border-mid)"
             aria-describedby="newsletter-error"
           />
           <div id="newsletter-error" class="mt-2 text-sm text-red-400 hidden" role="alert"></div>
@@ -33,7 +33,7 @@ export function renderNewsletter(): string {
         <button
           type="submit"
           class="w-full bg-slate-900 py-4 text-sm font-bold tracking-wide text-white transition-colors hover:bg-slate-800 inline-flex items-center justify-center gap-2"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
         >
           <i class="fa-solid fa-bell text-sm"></i>
           Subscribe to Alerts

--- a/src/components/PaginationComponent.ts
+++ b/src/components/PaginationComponent.ts
@@ -74,7 +74,7 @@ export function renderPagination(config: PaginationConfig): void {
     html += `
       <button
         class="px-4 md:px-6 py-2 md:py-3 text-xs font-bold tracking-wide bg-white text-slate-700 hover:bg-slate-50 transition-colors"
-        style="border: 2px solid #334155"
+        style="border: 2px solid var(--aucto-border-mid)"
         data-page="1"
         aria-label="Go to page 1"
       >

--- a/src/components/ProductCard.ts
+++ b/src/components/ProductCard.ts
@@ -55,9 +55,9 @@ export function createProductCard(listing: Listing): string {
   };
 
   return `
-    <article class="bg-white" style="border: 3px solid #1e293b" data-listing-id="${listing.id}">
+    <article class="bg-white" style="border: 3px solid var(--aucto-border-dark)" data-listing-id="${listing.id}">
       <!-- Image -->
-      <div class="aspect-square bg-slate-100" style="border-bottom: 3px solid #1e293b">
+      <div class="aspect-square bg-slate-100" style="border-bottom: 3px solid var(--aucto-border-dark)">
         <a href="/listing.html?id=${listing.id}" class="block h-full">
           <img
             src="${imgAttrs.src}"
@@ -77,7 +77,7 @@ export function createProductCard(listing: Listing): string {
       <!-- Content -->
       <div class="p-4 sm:p-5">
         <!-- Header: Lot Number + Status Badge -->
-        <div class="mb-3 flex items-center justify-between pb-3" style="border-bottom: 2px solid #e2e8f0">
+        <div class="mb-3 flex items-center justify-between pb-3" style="border-bottom: 2px solid var(--aucto-border-light)">
           <span class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500">
             Lot ${listing.id.slice(-3)}
           </span>
@@ -99,7 +99,7 @@ export function createProductCard(listing: Listing): string {
         </p>
 
         <!-- Bid Info Box -->
-        <div class="mb-4 bg-slate-50 p-3 sm:p-4" style="border: 2px solid #334155">
+        <div class="mb-4 bg-slate-50 p-3 sm:p-4" style="border: 2px solid var(--aucto-border-mid)">
           <div class="flex items-center justify-between gap-2">
             <div>
               <div class="mb-1 text-[10px] font-bold tracking-[0.18em] uppercase text-slate-500">
@@ -132,7 +132,7 @@ export function createProductCard(listing: Listing): string {
         <!-- CTA Button -->
         <button
           class="w-full bg-slate-900 py-3 text-sm font-bold tracking-wide text-white transition-colors hover:bg-slate-800 inline-flex items-center justify-center gap-2"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
           data-action="place-bid"
           data-listing-id="${listing.id}"
           ${!isActive ? 'disabled' : ''}
@@ -205,16 +205,16 @@ export function attachProductCardEvents(containerId: string = 'product-cards-gri
 
 export function createProductCardSkeleton(): string {
   return `
-    <div class="bg-white animate-pulse" style="border: 3px solid #1e293b">
-      <div class="aspect-square bg-slate-200" style="border-bottom: 3px solid #1e293b"></div>
+    <div class="bg-white animate-pulse" style="border: 3px solid var(--aucto-border-dark)">
+      <div class="aspect-square bg-slate-200" style="border-bottom: 3px solid var(--aucto-border-dark)"></div>
       <div class="p-4 sm:p-5">
-        <div class="mb-3 flex items-center justify-between pb-3" style="border-bottom: 2px solid #e2e8f0">
+        <div class="mb-3 flex items-center justify-between pb-3" style="border-bottom: 2px solid var(--aucto-border-light)">
           <div class="h-3 bg-slate-200 rounded w-16"></div>
           <div class="h-3 bg-slate-200 rounded w-12"></div>
         </div>
         <div class="h-6 bg-slate-200 rounded mb-2"></div>
         <div class="h-4 bg-slate-200 rounded mb-4 w-3/4"></div>
-        <div class="mb-4 bg-slate-50 p-3 sm:p-4" style="border: 2px solid #334155">
+        <div class="mb-4 bg-slate-50 p-3 sm:p-4" style="border: 2px solid var(--aucto-border-mid)">
           <div class="flex justify-between">
             <div class="h-10 bg-slate-200 rounded w-24"></div>
             <div class="h-10 bg-slate-200 rounded w-24"></div>

--- a/src/components/QuickCard.ts
+++ b/src/components/QuickCard.ts
@@ -26,9 +26,9 @@ export function createQuickCard(listing: Listing): string {
   const sellerName = listing.seller?.name || 'Unknown';
 
   return `
-    <article class="bg-white" style="border: 3px solid #1e293b" data-listing-id="${listing.id}">
+    <article class="bg-white" style="border: 3px solid var(--aucto-border-dark)" data-listing-id="${listing.id}">
       <!-- Image -->
-      <div class="h-48 bg-slate-100" style="border-bottom: 3px solid #1e293b">
+      <div class="h-48 bg-slate-100" style="border-bottom: 3px solid var(--aucto-border-dark)">
         <a href="/listing.html?id=${listing.id}" class="block h-full">
           <img
             src="${imgAttrs.src}"
@@ -48,7 +48,7 @@ export function createQuickCard(listing: Listing): string {
       <!-- Content -->
       <div class="p-6">
         <!-- Header: Lot Number + Time Badge -->
-        <div class="mb-4 flex items-center justify-between pb-4" style="border-bottom: 2px solid #e2e8f0">
+        <div class="mb-4 flex items-center justify-between pb-4" style="border-bottom: 2px solid var(--aucto-border-light)">
           <span class="text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500">
             Lot ${listing.id.slice(-3)}
           </span>
@@ -85,7 +85,7 @@ export function createQuickCard(listing: Listing): string {
         <!-- CTA Button -->
         <button
           class="w-full bg-slate-900 py-3 text-sm font-bold tracking-wide text-white transition-colors hover:bg-slate-800 inline-flex items-center justify-center gap-2"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
           data-action="place-bid"
           data-listing-id="${listing.id}"
           ${!isActive ? 'disabled' : ''}
@@ -158,10 +158,10 @@ export function attachQuickCardEvents(containerId: string = 'quick-cards-grid'):
 
 export function createQuickCardSkeleton(): string {
   return `
-    <div class="bg-white animate-pulse" style="border: 3px solid #1e293b">
-      <div class="h-48 bg-slate-200" style="border-bottom: 3px solid #1e293b"></div>
+    <div class="bg-white animate-pulse" style="border: 3px solid var(--aucto-border-dark)">
+      <div class="h-48 bg-slate-200" style="border-bottom: 3px solid var(--aucto-border-dark)"></div>
       <div class="p-6">
-        <div class="mb-4 flex items-center justify-between pb-4" style="border-bottom: 2px solid #e2e8f0">
+        <div class="mb-4 flex items-center justify-between pb-4" style="border-bottom: 2px solid var(--aucto-border-light)">
           <div class="h-3 bg-slate-200 rounded w-16"></div>
           <div class="h-3 bg-slate-200 rounded w-12"></div>
         </div>

--- a/src/components/StatsBar.ts
+++ b/src/components/StatsBar.ts
@@ -14,7 +14,7 @@ export interface StatsData {
 export function renderStatsBar(data: StatsData): string {
   return `
     <div class="mb-20 grid grid-cols-2 gap-6 md:grid-cols-4">
-      <div class="bg-slate-800 p-6 text-center" style="border: 3px solid #334155">
+      <div class="bg-slate-800 p-6 text-center" style="border: 3px solid var(--aucto-border-mid)">
         <div class="mb-2 text-4xl font-bold text-white" data-stat="myListings">
           ${new Intl.NumberFormat('en-US').format(data.myListings)}
         </div>
@@ -23,7 +23,7 @@ export function renderStatsBar(data: StatsData): string {
         </div>
       </div>
 
-      <div class="bg-slate-800 p-6 text-center" style="border: 3px solid #334155">
+      <div class="bg-slate-800 p-6 text-center" style="border: 3px solid var(--aucto-border-mid)">
         <div class="mb-2 text-4xl font-bold text-white" data-stat="myBids">
           ${new Intl.NumberFormat('en-US').format(data.myBids)}
         </div>
@@ -32,7 +32,7 @@ export function renderStatsBar(data: StatsData): string {
         </div>
       </div>
 
-      <div class="bg-slate-800 p-6 text-center" style="border: 3px solid #334155">
+      <div class="bg-slate-800 p-6 text-center" style="border: 3px solid var(--aucto-border-mid)">
         <div class="mb-2 text-4xl font-bold text-white" data-stat="winRate">
           ${data.winRate.toFixed(1)}%
         </div>
@@ -41,7 +41,7 @@ export function renderStatsBar(data: StatsData): string {
         </div>
       </div>
 
-      <div class="bg-slate-800 p-6 text-center" style="border: 3px solid #334155">
+      <div class="bg-slate-800 p-6 text-center" style="border: 3px solid var(--aucto-border-mid)">
         <div class="mb-2 text-4xl font-bold text-white" data-stat="activeBidsValue">
           ${formatCurrency(data.activeBidsValue, true)}
         </div>
@@ -173,7 +173,7 @@ export async function initStatsBar(): Promise<void> {
         .fill(0)
         .map(
           () => `
-        <div class="bg-slate-800 p-6 text-center" style="border: 3px solid #334155">
+        <div class="bg-slate-800 p-6 text-center" style="border: 3px solid var(--aucto-border-mid)">
           <div class="mb-2 text-4xl font-bold text-slate-700">
             <i class="fa-solid fa-spinner fa-spin"></i>
           </div>

--- a/src/components/filters/SearchField.ts
+++ b/src/components/filters/SearchField.ts
@@ -22,8 +22,8 @@ export function renderSearchField(config: SearchFieldConfig): string {
   } = config;
 
   const inputClasses = variant === 'compact'
-    ? 'w-full bg-slate-50 px-4 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none'
-    : 'w-full bg-slate-50 px-4 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none';
+    ? 'w-full bg-slate-50 px-4 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2'
+    : 'w-full bg-slate-50 px-4 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2';
 
   return `
     <div class="relative flex-1">
@@ -33,7 +33,7 @@ export function renderSearchField(config: SearchFieldConfig): string {
         placeholder="${placeholder}"
         value="${initialValue}"
         class="${inputClasses}"
-        style="border: 2px solid #334155"
+        style="border: 2px solid var(--aucto-border-mid)"
       />
       <i class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 fa-solid fa-magnifying-glass text-sm text-slate-400"></i>
     </div>

--- a/src/components/filters/SortDropdown.ts
+++ b/src/components/filters/SortDropdown.ts
@@ -35,8 +35,8 @@ export function renderSortDropdown(config: SortDropdownConfig): string {
   } = config;
 
   const selectClasses = variant === 'compact'
-    ? 'bg-white px-3 py-1.5 pr-7 text-[10px] font-bold tracking-[0.18em] uppercase text-slate-700 hover:bg-slate-50 focus:outline-none appearance-none'
-    : 'bg-white px-4 py-2 pr-8 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-700 hover:bg-slate-50 focus:outline-none appearance-none';
+    ? 'bg-white px-3 py-1.5 pr-7 text-[10px] font-bold tracking-[0.18em] uppercase text-slate-700 hover:bg-slate-50 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 appearance-none'
+    : 'bg-white px-4 py-2 pr-8 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-700 hover:bg-slate-50 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 appearance-none';
 
   const arrowSize = variant === 'compact'
     ? 'border-left: 3px solid transparent; border-right: 3px solid transparent; border-top: 5px solid #64748b;'
@@ -49,7 +49,7 @@ export function renderSortDropdown(config: SortDropdownConfig): string {
       <select
         id="${id}"
         class="${selectClasses}"
-        style="border: 2px solid #334155"
+        style="border: 2px solid var(--aucto-border-mid)"
       >
         ${SORT_OPTIONS.map((option) => `
           <option value="${option.value}" ${option.value === defaultValue ? 'selected' : ''}>

--- a/src/pages/Collection.ts
+++ b/src/pages/Collection.ts
@@ -313,14 +313,14 @@ function showError(message: string): void {
   if (!container) return;
 
   container.innerHTML = `
-    <div class="col-span-full bg-white p-12 text-center" style="border: 3px solid #1e293b">
+    <div class="col-span-full bg-white p-12 text-center" style="border: 3px solid var(--aucto-border-dark)">
       <i class="fa-solid fa-exclamation-circle text-6xl text-red-300 mb-4"></i>
       <h3 class="font-serif font-bold text-xl text-slate-900 mb-2">Error</h3>
       <p class="text-slate-600 mb-4">${message}</p>
       <button
         onclick="window.location.reload()"
         class="bg-slate-900 text-white px-6 py-3 hover:bg-slate-800 transition-colors"
-        style="border: 2px solid #1e293b"
+        style="border: 2px solid var(--aucto-border-dark)"
       >
         Reload Page
       </button>

--- a/src/pages/Home.ts
+++ b/src/pages/Home.ts
@@ -298,7 +298,7 @@ function showNoListingsMessage(): void {
   const heroMosaic = document.getElementById('hero-mosaic');
   if (heroMosaic) {
     heroMosaic.innerHTML = `
-      <div class="flex items-center justify-center p-12 bg-slate-50" style="border: 3px solid #1e293b">
+      <div class="flex items-center justify-center p-12 bg-slate-50" style="border: 3px solid var(--aucto-border-dark)">
         <p class="text-slate-600">No featured listings available at this time.</p>
       </div>
     `;
@@ -314,7 +314,7 @@ function showErrorInSections(): void {
       <button
         onclick="window.location.reload()"
         class="bg-slate-900 text-white px-6 py-3 hover:bg-slate-800 transition-colors"
-        style="border: 2px solid #1e293b"
+        style="border: 2px solid var(--aucto-border-dark)"
       >
         Reload Page
       </button>
@@ -356,7 +356,7 @@ function renderHeroSection(): void {
 
   if (featured.length === 0) {
     heroMosaic.innerHTML = `
-      <div class="col-span-full flex items-center justify-center p-12 bg-slate-50" style="border: 3px solid #1e293b">
+      <div class="col-span-full flex items-center justify-center p-12 bg-slate-50" style="border: 3px solid var(--aucto-border-dark)">
         <p class="text-slate-600">No featured listings available at this time.</p>
       </div>
     `;
@@ -372,8 +372,8 @@ function renderHeroSection(): void {
 
   let mosaicHTML = `
     <!-- Main featured lot -->
-    <article class="row-span-1 bg-slate-50" style="border: 3px solid #1e293b">
-      <div class="relative h-40 sm:h-48 md:h-52 bg-slate-200" style="border-bottom: 3px solid #1e293b">
+    <article class="row-span-1 bg-slate-50" style="border: 3px solid var(--aucto-border-dark)">
+      <div class="relative h-40 sm:h-48 md:h-52 bg-slate-200" style="border-bottom: 3px solid var(--aucto-border-dark)">
         <a href="/listing.html?id=${main.id}" class="block h-full">
           <img
             src="${mainImage}"
@@ -385,7 +385,7 @@ function renderHeroSection(): void {
           <i class="fa-solid fa-fire text-amber-400"></i>
           <span>Hot</span>
         </div>
-        <div class="absolute right-4 bottom-4 bg-white px-3 py-1 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-900" style="border: 2px solid #1e293b">
+        <div class="absolute right-4 bottom-4 bg-white px-3 py-1 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-900" style="border: 2px solid var(--aucto-border-dark)">
           ${mainTimeRemaining}
         </div>
       </div>
@@ -425,8 +425,8 @@ function renderHeroSection(): void {
       const highestBid = bids.length > 0 ? Math.max(...bids.map(b => b.amount)) : 0;
 
       mosaicHTML += `
-        <article class="bg-slate-50" style="border: 3px solid #1e293b">
-          <div class="h-48 sm:h-52 md:h-56 bg-slate-200" style="border-bottom: 3px solid #1e293b">
+        <article class="bg-slate-50" style="border: 3px solid var(--aucto-border-dark)">
+          <div class="h-48 sm:h-52 md:h-56 bg-slate-200" style="border-bottom: 3px solid var(--aucto-border-dark)">
             <a href="/listing.html?id=${listing.id}" class="block h-full">
               <img
                 src="${image}"

--- a/src/pages/ListingCreate.ts
+++ b/src/pages/ListingCreate.ts
@@ -33,11 +33,11 @@ function renderCreateForm(): void {
   if (!container) return;
 
   container.innerHTML = `
-    <div class="bg-white p-6 md:p-10" style="border: 3px solid #1e293b">
+    <div class="bg-white p-6 md:p-10" style="border: 3px solid var(--aucto-border-dark)">
       <!-- Header -->
       <div class="mb-8 md:mb-10 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
         <div class="flex items-center gap-4">
-          <div class="h-0.5 w-14 bg-red-700"></div>
+          <div class="h-0.5 w-14 bg-aucto-red"></div>
           <h1 class="text-[12px] font-bold tracking-[0.18em] uppercase text-slate-500">
             Create new listing
           </h1>
@@ -83,7 +83,7 @@ function renderCreateForm(): void {
               id="title"
               name="title"
               placeholder="e.g., Vintage camera set"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700"
               required
             />
           </div>
@@ -98,7 +98,7 @@ function renderCreateForm(): void {
               name="description"
               rows="6"
               placeholder="Describe the condition, features, and any important notes about your item…"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700 resize-none"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700 resize-none"
               required
             ></textarea>
           </div>
@@ -113,7 +113,7 @@ function renderCreateForm(): void {
               name="media"
               rows="4"
               placeholder="https://example.com/image1.jpg&#10;https://example.com/image2.jpg&#10;https://example.com/image3.jpg"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700 resize-none"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700 resize-none"
             ></textarea>
             <p class="mt-2 text-xs text-slate-500">
               Enter one image URL per line. Images will preview on the right.
@@ -130,7 +130,7 @@ function renderCreateForm(): void {
               id="tags"
               name="tags"
               placeholder="e.g., vintage, camera, photography"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700"
             />
             <p class="mt-2 text-xs text-slate-500">
               Separate tags with commas
@@ -146,7 +146,7 @@ function renderCreateForm(): void {
               type="datetime-local"
               id="endsAt"
               name="endsAt"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700"
               required
             />
           </div>
@@ -175,7 +175,7 @@ function renderCreateForm(): void {
           <!-- Main Preview Image -->
           <div
             class="relative h-64 md:h-80 bg-slate-200 overflow-hidden"
-            style="border: 3px solid #1e293b"
+            style="border: 3px solid var(--aucto-border-dark)"
             id="mainPreview"
           >
             <div class="w-full h-full flex items-center justify-center text-slate-400">

--- a/src/pages/ListingDetail.ts
+++ b/src/pages/ListingDetail.ts
@@ -107,7 +107,7 @@ function showError(message: string) {
     main.innerHTML = `
       <div class="bg-warm-white py-16">
         <div class="mx-auto max-w-7xl px-6 md:px-8">
-          <div class="bg-white p-8 text-center" style="border: 3px solid #1e293b">
+          <div class="bg-white p-8 text-center" style="border: 3px solid var(--aucto-border-dark)">
             <i class="fa-solid fa-exclamation-triangle text-4xl text-red-700 mb-4"></i>
             <h1 class="text-2xl font-bold text-slate-900 mb-2">Error</h1>
             <p class="text-slate-600">${message}</p>
@@ -193,7 +193,7 @@ function renderMediaGallery(listing: Listing) {
 
   gallery.innerHTML = `
     <!-- Main image -->
-    <div class="aspect-[4/3] bg-slate-100 mb-4 md:mb-6" style="border: 3px solid #1e293b">
+    <div class="aspect-[4/3] bg-slate-100 mb-4 md:mb-6" style="border: 3px solid var(--aucto-border-dark)">
       <img
         id="main-image"
         src="${mainImgAttrs.src}"
@@ -283,7 +283,7 @@ function renderListingDetails(listing: Listing) {
     <h3 class="mb-4 text-xs font-bold tracking-[0.18em] uppercase text-slate-500">
       Details
     </h3>
-    <div class="flex flex-wrap gap-6 text-xs text-slate-600 mb-6 pb-6" style="border-bottom: 2px solid #e2e8f0">
+    <div class="flex flex-wrap gap-6 text-xs text-slate-600 mb-6 pb-6" style="border-bottom: 2px solid var(--aucto-border-light)">
       ${listing.tags && listing.tags.length > 0 ? `
         <div>
           <div class="mb-1 font-bold tracking-[0.18em] uppercase text-slate-500 inline-flex items-center gap-1">
@@ -353,7 +353,7 @@ function renderBidPanel(listing: Listing) {
       ` : ''}
     </div>
 
-    <div class="mb-10 pb-6" style="border-bottom: 2px solid #e2e8f0">
+    <div class="mb-10 pb-6" style="border-bottom: 2px solid var(--aucto-border-light)">
       <div class="mb-3 text-xs font-bold tracking-[0.18em] uppercase text-slate-500 inline-flex items-center gap-1">
         <i class="fa-solid fa-clock text-xs ${isActive ? 'text-red-700' : 'text-slate-500'}"></i>
         <span>Time Remaining</span>
@@ -375,8 +375,8 @@ function renderBidPanel(listing: Listing) {
             min="${minimumBid}"
             value="${minimumBid}"
             step="1"
-            class="w-full bg-slate-50 px-4 py-4 text-lg font-bold text-slate-900 focus:outline-none"
-            style="border: 2px solid #334155"
+            class="w-full bg-slate-50 px-4 py-4 text-lg font-bold text-slate-900 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+            style="border: 2px solid var(--aucto-border-mid)"
             required
           />
           <div class="mt-3 text-xs text-slate-500">
@@ -393,7 +393,7 @@ function renderBidPanel(listing: Listing) {
           type="submit"
           id="place-bid-btn"
           class="w-full bg-slate-900 px-6 py-4 text-sm font-bold tracking-[0.18em] uppercase text-white hover:bg-slate-800 transition-colors inline-flex items-center justify-center gap-2 mt-2"
-          style="border: 2px solid #1e293b"
+          style="border: 2px solid var(--aucto-border-dark)"
         >
           <i class="fa-solid fa-gavel text-base"></i>
           <span>Place Bid</span>
@@ -408,7 +408,7 @@ function renderBidPanel(listing: Listing) {
         <a
           href="/login.html?redirect=${encodeURIComponent(window.location.pathname + window.location.search)}"
           class="w-full bg-slate-900 px-6 py-4 text-sm font-bold tracking-[0.18em] uppercase text-white hover:bg-slate-800 transition-colors inline-flex items-center justify-center gap-2"
-          style="border: 2px solid #1e293b"
+          style="border: 2px solid var(--aucto-border-dark)"
         >
           <i class="fa-solid fa-right-to-bracket text-base"></i>
           <span>Login to Bid</span>
@@ -418,7 +418,7 @@ function renderBidPanel(listing: Listing) {
         </div>
       </div>
     ` : `
-      <div class="bg-slate-100 px-6 py-10 text-center mt-6" style="border: 2px solid #334155">
+      <div class="bg-slate-100 px-6 py-10 text-center mt-6" style="border: 2px solid var(--aucto-border-mid)">
         <i class="fa-solid fa-circle-xmark text-3xl text-slate-500 mb-4"></i>
         <p class="text-sm font-bold text-slate-700">This auction has ended</p>
       </div>
@@ -636,7 +636,7 @@ function renderTags(listing: Listing) {
       ${listing.tags.map(tag => `
         <span
           class="bg-slate-50 px-3 py-2 text-[11px] font-bold tracking-[0.18em] text-slate-700 uppercase"
-          style="border: 2px solid #334155"
+          style="border: 2px solid var(--aucto-border-mid)"
         >
           ${tag}
         </span>
@@ -673,7 +673,7 @@ function renderBidHistory(listing: Listing) {
         const isUserBid = user && bid.bidder?.name === user.name;
 
         return `
-          <div class="flex items-start justify-between gap-4 py-4 ${index < sortedBids.length - 1 ? 'border-b-2' : ''}" style="border-color: #e2e8f0">
+          <div class="flex items-start justify-between gap-4 py-4 ${index < sortedBids.length - 1 ? 'border-b-2' : ''}" style="border-color: var(--aucto-border-light)">
             <div>
               <div class="text-base font-bold text-slate-900 mb-1">
                 ${new Intl.NumberFormat('en-US').format(bid.amount)} Credits
@@ -716,8 +716,8 @@ function renderSellerProfile(listing: Listing) {
     : null;
 
   profile.innerHTML = `
-    <div class="mb-6 flex items-center gap-4 pb-6" style="border-bottom: 2px solid #e2e8f0">
-      <div class="h-16 w-16 bg-slate-100 flex-shrink-0" style="border: 2px solid #1e293b">
+    <div class="mb-6 flex items-center gap-4 pb-6" style="border-bottom: 2px solid var(--aucto-border-light)">
+      <div class="h-16 w-16 bg-slate-100 flex-shrink-0" style="border: 2px solid var(--aucto-border-dark)">
         ${avatarAttrs ? `
           <img
             src="${avatarAttrs.src}"
@@ -749,12 +749,12 @@ function renderSellerProfile(listing: Listing) {
     </div>
 
     ${seller.bio ? `
-      <p class="text-sm leading-relaxed text-slate-600 mb-6 pb-6" style="border-bottom: 2px solid #e2e8f0">
+      <p class="text-sm leading-relaxed text-slate-600 mb-6 pb-6" style="border-bottom: 2px solid var(--aucto-border-light)">
         ${seller.bio}
       </p>
     ` : ''}
 
-    <div class="pt-6" style="border-top: 2px solid #e2e8f0">
+    <div class="pt-6" style="border-top: 2px solid var(--aucto-border-light)">
       <a
         href="/profile.html?user=${seller.name}"
         class="inline-flex items-center gap-2 text-sm font-bold text-slate-900 hover:text-slate-700 transition-colors"
@@ -777,19 +777,19 @@ function renderListingMeta(listing: Listing) {
 
   meta.innerHTML = `
     <dl class="space-y-0">
-      <div class="flex justify-between gap-4 py-4" style="border-bottom: 2px solid #e2e8f0">
+      <div class="flex justify-between gap-4 py-4" style="border-bottom: 2px solid var(--aucto-border-light)">
         <dt class="text-xs font-bold tracking-[0.18em] uppercase text-slate-500">
           Listing ID
         </dt>
         <dd class="text-sm font-mono text-slate-900">${listing.id.substring(0, 12)}...</dd>
       </div>
-      <div class="flex justify-between gap-4 py-4" style="border-bottom: 2px solid #e2e8f0">
+      <div class="flex justify-between gap-4 py-4" style="border-bottom: 2px solid var(--aucto-border-light)">
         <dt class="text-xs font-bold tracking-[0.18em] uppercase text-slate-500">
           Created
         </dt>
         <dd class="text-sm text-slate-900 text-right">${formatDate(listing.created)}</dd>
       </div>
-      <div class="flex justify-between gap-4 py-4" style="border-bottom: 2px solid #e2e8f0">
+      <div class="flex justify-between gap-4 py-4" style="border-bottom: 2px solid var(--aucto-border-light)">
         <dt class="text-xs font-bold tracking-[0.18em] uppercase text-slate-500">
           Ends
         </dt>
@@ -797,7 +797,7 @@ function renderListingMeta(listing: Listing) {
           ${formatDate(listing.endsAt)}
         </dd>
       </div>
-      <div class="flex justify-between gap-4 py-4" style="border-bottom: 2px solid #e2e8f0">
+      <div class="flex justify-between gap-4 py-4" style="border-bottom: 2px solid var(--aucto-border-light)">
         <dt class="text-xs font-bold tracking-[0.18em] uppercase text-slate-500">
           Total Bids
         </dt>
@@ -813,7 +813,7 @@ function renderListingMeta(listing: Listing) {
       </div>
     </dl>
 
-    <div class="mt-0 pt-6 text-xs text-slate-500 leading-relaxed" style="border-top: 2px solid #e2e8f0">
+    <div class="mt-0 pt-6 text-xs text-slate-500 leading-relaxed" style="border-top: 2px solid var(--aucto-border-light)">
       <p>
         All bids are binding. By placing a bid you agree to the platform
         terms and conditions and confirm you have sufficient credits at

--- a/src/pages/ListingEdit.ts
+++ b/src/pages/ListingEdit.ts
@@ -84,11 +84,11 @@ function renderEditForm(listing: Listing, hasBids: boolean): void {
   const tags = listing.tags?.join(', ') || '';
 
   container.innerHTML = `
-    <div class="bg-white p-10" style="border: 3px solid #1e293b">
+    <div class="bg-white p-10" style="border: 3px solid var(--aucto-border-dark)">
       <!-- HEADER -->
       <div class="mb-10 flex items-center justify-between">
         <div class="flex items-center gap-4">
-          <div class="h-0.5 w-14 bg-red-700"></div>
+          <div class="h-0.5 w-14 bg-aucto-red"></div>
           <h1 class="text-[12px] font-bold tracking-[0.18em] uppercase text-slate-500">
             Edit listing
           </h1>
@@ -134,7 +134,7 @@ function renderEditForm(listing: Listing, hasBids: boolean): void {
               id="title"
               name="title"
               value="${listing.title}"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700"
               required
               ${hasBids ? 'disabled' : ''}
             />
@@ -152,7 +152,7 @@ function renderEditForm(listing: Listing, hasBids: boolean): void {
               id="description"
               name="description"
               rows="6"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700"
               required
             >${listing.description || ''}</textarea>
           </div>
@@ -168,7 +168,7 @@ function renderEditForm(listing: Listing, hasBids: boolean): void {
               id="imageUrls"
               name="media"
               rows="4"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700"
             >${imageUrls}</textarea>
             <p class="mt-2 text-xs text-slate-500">
               Enter one image URL per line. Images will preview on the right.
@@ -188,7 +188,7 @@ function renderEditForm(listing: Listing, hasBids: boolean): void {
               name="tags"
               value="${tags}"
               placeholder="e.g., vintage, tech, collectible"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700"
             />
             <p class="mt-2 text-xs text-slate-500">
               Separate tags with commas
@@ -207,7 +207,7 @@ function renderEditForm(listing: Listing, hasBids: boolean): void {
               id="endDate"
               name="endsAt"
               value="${formattedDate}"
-              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline-none focus:border-red-700"
+              class="w-full px-4 py-3 bg-white border-2 border-slate-800 text-sm focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2 focus:border-red-700"
               required
             />
           </div>
@@ -236,7 +236,7 @@ function renderEditForm(listing: Listing, hasBids: boolean): void {
           <!-- MAIN PREVIEW -->
           <div
             class="relative h-80 bg-slate-200 border-3 border-slate-900 overflow-hidden"
-            style="border: 3px solid #1e293b"
+            style="border: 3px solid var(--aucto-border-dark)"
             id="mainPreview"
           >
             ${listing.media?.[0]?.url ? `
@@ -297,7 +297,7 @@ function renderEditForm(listing: Listing, hasBids: boolean): void {
       <!-- DANGER ZONE -->
       <div class="mt-16 pt-10 border-t-2 border-slate-200">
         <div class="flex items-center gap-4 mb-6">
-          <div class="h-0.5 w-14 bg-red-700"></div>
+          <div class="h-0.5 w-14 bg-aucto-red"></div>
           <span class="text-[12px] font-bold tracking-[0.18em] uppercase text-red-700">
             Danger Zone
           </span>
@@ -568,14 +568,14 @@ function showError(message: string): void {
   if (!container) return;
 
   container.innerHTML = `
-    <div class="bg-white p-8 text-center" style="border: 3px solid #1e293b">
+    <div class="bg-white p-8 text-center" style="border: 3px solid var(--aucto-border-dark)">
       <i class="fa-solid fa-exclamation-circle text-6xl text-red-300 mb-4"></i>
       <h3 class="font-serif font-bold text-xl text-slate-900 mb-2">Error</h3>
       <p class="text-slate-600 mb-4">${message}</p>
       <button
         onclick="window.history.back()"
         class="bg-slate-900 text-white px-6 py-3 hover:bg-slate-800 transition-colors"
-        style="border: 2px solid #1e293b"
+        style="border: 2px solid var(--aucto-border-dark)"
       >
         Go Back
       </button>

--- a/src/pages/ProfilePage.ts
+++ b/src/pages/ProfilePage.ts
@@ -164,11 +164,11 @@ function renderProfileHero(
       </nav>
 
       <!-- Main hero card -->
-      <div class="bg-white relative" style="border: 3px solid #1e293b">
+      <div class="bg-white relative" style="border: 3px solid var(--aucto-border-dark)">
         <!-- Banner -->
         <div
           class="relative h-40 md:h-48 bg-slate-200"
-          style="border-bottom: 3px solid #1e293b; min-height: 10rem;"
+          style="border-bottom: 3px solid var(--aucto-border-dark); min-height: 10rem;"
         >
           ${
             bannerUrl
@@ -191,7 +191,7 @@ function renderProfileHero(
           <!-- Avatar -->
           <div
             class="w-28 h-28 flex-shrink-0 bg-white"
-            style="border: 3px solid #1e293b;"
+            style="border: 3px solid var(--aucto-border-dark);"
           >
             ${
               avatarUrl
@@ -246,7 +246,7 @@ function renderProfileHero(
             <button
               id="edit-profile-btn"
               class="bg-slate-900 px-6 py-3 text-xs font-bold tracking-wide text-white hover:bg-slate-800 inline-flex items-center gap-2"
-              style="border: 2px solid #1e293b"
+              style="border: 2px solid var(--aucto-border-dark)"
             >
               <i class="fa-solid fa-pen-to-square text-sm"></i>
               <span>Edit profile</span>
@@ -254,7 +254,7 @@ function renderProfileHero(
             <a
               href="/listing-create.html"
               class="bg-white px-6 py-3 text-xs font-bold tracking-wide text-slate-900 hover:bg-slate-50 inline-flex items-center gap-2 justify-center"
-              style="border: 2px solid #334155"
+              style="border: 2px solid var(--aucto-border-mid)"
             >
               <i class="fa-solid fa-plus text-sm"></i>
               <span>Create listing</span>
@@ -269,7 +269,7 @@ function renderProfileHero(
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <div
           class="bg-white px-6 py-5 text-center"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
         >
           <div
             class="mb-1 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500 inline-flex items-center justify-center gap-1"
@@ -281,7 +281,7 @@ function renderProfileHero(
         </div>
         <div
           class="bg-white px-6 py-5 text-center"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
         >
           <div
             class="mb-1 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500 inline-flex items-center justify-center gap-1"
@@ -293,7 +293,7 @@ function renderProfileHero(
         </div>
         <div
           class="bg-white px-6 py-5 text-center"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
         >
           <div
             class="mb-1 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500 inline-flex items-center justify-center gap-1"
@@ -305,7 +305,7 @@ function renderProfileHero(
         </div>
         <div
           class="bg-white px-6 py-5 text-center"
-          style="border: 3px solid #1e293b"
+          style="border: 3px solid var(--aucto-border-dark)"
         >
           <div
             class="mb-1 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-500 inline-flex items-center justify-center gap-1"
@@ -325,7 +325,7 @@ function renderAboutAndSettings(profile: Profile, isOwnProfile: boolean): string
     <section>
       <div class="grid gap-6 ${isOwnProfile ? 'lg:grid-cols-2' : 'lg:grid-cols-1'}">
         <!-- About card -->
-        <div class="bg-white p-8 md:p-10" style="border: 3px solid #1e293b">
+        <div class="bg-white p-8 md:p-10" style="border: 3px solid var(--aucto-border-dark)">
           <h2 class="mb-4 text-3xl font-bold text-slate-900">
             About this seller
           </h2>
@@ -371,7 +371,7 @@ function renderAboutAndSettings(profile: Profile, isOwnProfile: boolean): string
         <!-- Settings card (only show for own profile) -->
         ${
           isOwnProfile
-            ? `<div class="bg-white p-8 md:p-10" style="border: 3px solid #1e293b">
+            ? `<div class="bg-white p-8 md:p-10" style="border: 3px solid var(--aucto-border-dark)">
           <h2 class="mb-4 text-2xl font-bold text-slate-900">
             Profile settings
           </h2>
@@ -388,8 +388,8 @@ function renderAboutAndSettings(profile: Profile, isOwnProfile: boolean): string
               </label>
               <textarea
                 id="bio-input"
-                class="w-full bg-slate-50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                style="border: 2px solid #334155"
+                class="w-full bg-slate-50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                style="border: 2px solid var(--aucto-border-mid)"
                 rows="3"
                 placeholder="Short description about yourself"
               >${profile.bio || ''}</textarea>
@@ -404,8 +404,8 @@ function renderAboutAndSettings(profile: Profile, isOwnProfile: boolean): string
               <input
                 id="avatar-input"
                 type="url"
-                class="w-full bg-slate-50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                style="border: 2px solid #334155"
+                class="w-full bg-slate-50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                style="border: 2px solid var(--aucto-border-mid)"
                 placeholder="https://url.com/avatar.jpg"
                 value="${profile.avatar?.url || ''}"
               />
@@ -420,8 +420,8 @@ function renderAboutAndSettings(profile: Profile, isOwnProfile: boolean): string
               <input
                 id="banner-input"
                 type="url"
-                class="w-full bg-slate-50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none"
-                style="border: 2px solid #334155"
+                class="w-full bg-slate-50 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline focus:outline-[3px] focus:outline-aucto-red focus:outline-offset-2"
+                style="border: 2px solid var(--aucto-border-mid)"
                 placeholder="https://url.com/banner.jpg"
                 value="${profile.banner?.url || ''}"
               />
@@ -430,7 +430,7 @@ function renderAboutAndSettings(profile: Profile, isOwnProfile: boolean): string
             <button
               type="submit"
               class="mt-4 w-full bg-slate-900 py-3 text-xs font-bold tracking-wide text-white hover:bg-slate-800 inline-flex items-center justify-center gap-2"
-              style="border: 2px solid #1e293b"
+              style="border: 2px solid var(--aucto-border-dark)"
             >
               <i class="fa-solid fa-floppy-disk text-base"></i>
               <span>Save profile changes</span>
@@ -448,7 +448,7 @@ function renderActiveListings(listings: Listing[], isOwnProfile: boolean): strin
   if (listings.length === 0) {
     return `
       <section>
-        <div class="bg-white p-8 md:p-10" style="border: 3px solid #1e293b">
+        <div class="bg-white p-8 md:p-10" style="border: 3px solid var(--aucto-border-dark)">
           <div class="mb-6 flex flex-wrap items-baseline justify-between gap-4">
             <div>
               <h2 class="text-3xl font-bold text-slate-900">Active listings</h2>
@@ -461,7 +461,7 @@ function renderActiveListings(listings: Listing[], isOwnProfile: boolean): strin
                 ? `<a
               href="/listing-create.html"
               class="inline-flex items-center gap-2 bg-slate-900 px-6 py-3 text-xs font-bold tracking-wide text-white hover:bg-slate-800"
-              style="border: 2px solid #1e293b"
+              style="border: 2px solid var(--aucto-border-dark)"
             >
               <i class="fa-solid fa-plus text-sm"></i>
               <span>Create listing</span>
@@ -485,7 +485,7 @@ function renderActiveListings(listings: Listing[], isOwnProfile: boolean): strin
 
   return `
     <section>
-      <div class="bg-white p-8 md:p-10" style="border: 3px solid #1e293b">
+      <div class="bg-white p-8 md:p-10" style="border: 3px solid var(--aucto-border-dark)">
         <div class="mb-6 flex flex-wrap items-baseline justify-between gap-4">
           <div>
             <h2 class="text-3xl font-bold text-slate-900">Active listings</h2>
@@ -498,7 +498,7 @@ function renderActiveListings(listings: Listing[], isOwnProfile: boolean): strin
               ? `<a
             href="/listing-create.html"
             class="inline-flex items-center gap-2 bg-slate-900 px-6 py-3 text-xs font-bold tracking-wide text-white hover:bg-slate-800"
-            style="border: 2px solid #1e293b"
+            style="border: 2px solid var(--aucto-border-dark)"
           >
             <i class="fa-solid fa-plus text-sm"></i>
             <span>Create listing</span>
@@ -527,11 +527,11 @@ function renderListingCard(listing: Listing, isOwnProfile: boolean): string {
   return `
     <article
       class="bg-white transition-all hover:-translate-y-1"
-      style="border: 2px solid #1e293b"
+      style="border: 2px solid var(--aucto-border-dark)"
     >
       <div
         class="aspect-square bg-slate-100"
-        style="border-bottom: 2px solid #1e293b"
+        style="border-bottom: 2px solid var(--aucto-border-dark)"
       >
         ${
           imageUrl
@@ -567,7 +567,7 @@ function renderListingCard(listing: Listing, isOwnProfile: boolean): string {
           <a
             href="/listing.html?id=${listing.id}"
             class="flex-1 bg-slate-900 py-3 text-xs font-bold tracking-wide text-white hover:bg-slate-800 inline-flex items-center justify-center gap-2"
-            style="border: 2px solid #1e293b"
+            style="border: 2px solid var(--aucto-border-dark)"
           >
             <i class="fa-solid fa-eye text-sm"></i>
             <span>View</span>
@@ -577,7 +577,7 @@ function renderListingCard(listing: Listing, isOwnProfile: boolean): string {
               ? `<a
             href="/listing-edit.html?id=${listing.id}"
             class="bg-white py-3 px-4 text-xs font-bold tracking-wide text-slate-900 hover:bg-slate-50 inline-flex items-center justify-center"
-            style="border: 2px solid #334155"
+            style="border: 2px solid var(--aucto-border-mid)"
             title="Edit listing"
           >
             <i class="fa-solid fa-pen text-sm"></i>
@@ -595,7 +595,7 @@ function renderWinsAndBids(wins: Listing[], bids: Bid[]): string {
     <section>
       <div class="grid gap-6 lg:grid-cols-2">
         <!-- Wins -->
-        <div class="bg-white p-8 md:p-10" style="border: 3px solid #1e293b">
+        <div class="bg-white p-8 md:p-10" style="border: 3px solid var(--aucto-border-dark)">
           <h2 class="mb-4 text-2xl font-bold text-slate-900">Recent wins</h2>
           <p class="mb-6 text-sm text-slate-600">
             ${wins.length === 0 ? 'You haven\'t won any auctions yet' : `You have won ${wins.length} ${wins.length === 1 ? 'auction' : 'auctions'}`}
@@ -616,7 +616,7 @@ function renderWinsAndBids(wins: Listing[], bids: Bid[]): string {
         </div>
 
         <!-- Bids -->
-        <div class="bg-white p-8 md:p-10" style="border: 3px solid #1e293b">
+        <div class="bg-white p-8 md:p-10" style="border: 3px solid var(--aucto-border-dark)">
           <h2 class="mb-4 text-2xl font-bold text-slate-900">
             Recent bid activity
           </h2>
@@ -791,14 +791,14 @@ function showError(message: string): void {
   if (!container) return;
 
   container.innerHTML = `
-    <div class="bg-white p-8 text-center" style="border: 3px solid #1e293b">
+    <div class="bg-white p-8 text-center" style="border: 3px solid var(--aucto-border-dark)">
       <i class="fa-solid fa-exclamation-circle text-6xl text-red-300 mb-4"></i>
       <h3 class="font-serif font-bold text-xl text-slate-900 mb-2">Error</h3>
       <p class="text-slate-600 mb-4">${message}</p>
       <a
         href="/index.html"
         class="inline-block bg-slate-900 text-white px-6 py-3 hover:bg-slate-800 transition-colors"
-        style="border: 2px solid #1e293b"
+        style="border: 2px solid var(--aucto-border-dark)"
       >
         Go to Home
       </a>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2,6 +2,18 @@
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
+/*
+ * Design tokens.
+
+ */
+:root {
+  --aucto-bg: #f7f7f5;
+  --aucto-border-light: #e2e8f0;
+  --aucto-border-mid: #334155;
+  --aucto-border-dark: #1e293b;
+  --aucto-red: #dc2629;
+}
+
 /* Custom styles */
 body {
   font-family: "Source Sans 3", system-ui, -apple-system, sans-serif;


### PR DESCRIPTION
  - Add :root CSS variables (--aucto-bg, --aucto-border-light/mid/dark, --aucto-red) mirroring tailwind.config.js
  - Sweep ~150 inline border hex values to var() references across all 8 HTML pages and ~15 TS components/pages
  - Replace decorative bg-red-700 accent lines with bg-aucto-red; destructive UI keeps red-700
  - Remove blue from CollectionCard and FeaturedWin status colors
  - Fix CollectionCard skeleton border 2px -> 3px to eliminate
  - Add visible focus rings (3px aucto-red outline) to 21 form layout shift when content loadsinputs replacing focus:outline-none