### PR TITLE
fix: disabled-state affordance and guest-button handler cleanup

### DIFF
--- a/login.html
+++ b/login.html
@@ -188,9 +188,9 @@
                   </a>
                   <button
                     type="button"
+                    id="guest-continue-btn"
                     class="w-full bg-slate-50 py-2 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-600 hover:bg-slate-100 inline-flex items-center justify-center gap-2"
                     style="border: 1px dashed #cbd5e1"
-                    onclick="window.location.href='/index.html'"
                   >
                     <i class="text-xs fa-solid fa-arrow-right-to-bracket"></i>
                     Continue as guest

--- a/register.html
+++ b/register.html
@@ -240,9 +240,9 @@
                   </a>
                   <button
                     type="button"
+                    id="guest-continue-btn"
                     class="w-full bg-slate-50 py-2 text-[11px] font-bold tracking-[0.18em] uppercase text-slate-600 hover:bg-slate-100 inline-flex items-center justify-center gap-2"
                     style="border: 1px dashed #cbd5e1"
-                    onclick="window.location.href='/index.html'"
                   >
                     <i class="text-xs fa-solid fa-arrow-right-to-bracket"></i>
                     Continue as guest

--- a/src/pages/Login.ts
+++ b/src/pages/Login.ts
@@ -26,6 +26,14 @@ export async function initLoginPage(): Promise<void> {
   // Handle form submission
   form.addEventListener('submit', handleLoginSubmit);
 
+  // Continue-as-guest button
+  const guestBtn = document.getElementById('guest-continue-btn');
+  if (guestBtn) {
+    guestBtn.addEventListener('click', () => {
+      window.location.href = '/index.html';
+    });
+  }
+
   // Real-time validation
   const emailInput = document.getElementById('email') as HTMLInputElement;
   if (emailInput) {

--- a/src/pages/Register.ts
+++ b/src/pages/Register.ts
@@ -33,6 +33,14 @@ export async function initRegisterPage(): Promise<void> {
   // Handle form submission
   form.addEventListener('submit', handleRegisterSubmit);
 
+  // Continue-as-guest button
+  const guestBtn = document.getElementById('guest-continue-btn');
+  if (guestBtn) {
+    guestBtn.addEventListener('click', () => {
+      window.location.href = '/index.html';
+    });
+  }
+
   // Real-time validation
   const nameInput = document.getElementById('name') as HTMLInputElement;
   if (nameInput) {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -38,3 +38,18 @@ h1, h2, h3, h4, h5, h6 {
 html {
   scroll-behavior: smooth;
 }
+
+/* Disabled-control affordance */
+button:disabled,
+input:disabled,
+select:disabled,
+textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+input:disabled,
+select:disabled,
+textarea:disabled {
+  background-color: var(--aucto-bg);
+}


### PR DESCRIPTION
## Purpose

Part of preparing **Aucto (Semester Project 2)** for the **Portfolio 2 Course Assignment**, which requires at least one meaningful improvement to each showcased project. A fresh-eyes presentation-readiness audit confirmed the project is otherwise solid (clean type-check, 53/53 tests, green build, empty-states and mobile-menu already handled) and
  surfaced one genuine accessibility/UX gap plus one consistency issue.
  
  ## Issues
  
1. **Disabled controls gave no visual feedback.** Seven flows set `element.disabled = true` during submit/loading, but there was no `:disabled` styling anywhere. A submitting button looked identical to a live one, so users got no signal it was inert and could click again. The same applied to the listing-edit end-date input, which is deliberately locked once an auction has bids.

2. **Two inline `onclick` handlers remained.** The "Continue as guest" buttons on the login and register pages used `onclick="window.location.href=..."`, the only inline handlers left, breaking the codebase's event-delegation convention.
  
## Fix
  
- **`src/styles/main.css`** one global rule fades disabled buttons/inputs and shows a `not-allowed` cursor, with a muted `--aucto-bg` background on disabled inputs so locked fields read as locked. A single source of truth covers all current and future disabled controls without per-element edits, consistent with the design-token approach from #113.

- **`login.html` / `register.html` / `Login.ts` / `Register.ts`** — inline `onclick` replaced with an `id` + `addEventListener` in the page module.

  ## Related work
  
  This is the fifth in a series of improvements preparing Aucto for professional presentation:

- #111
- #112
- #113
- #114